### PR TITLE
[ICC-128] 기본 구조 작성

### DIFF
--- a/src/main/java/com/icc/qasker/global/entity/CreatedAt.java
+++ b/src/main/java/com/icc/qasker/global/entity/CreatedAt.java
@@ -1,0 +1,17 @@
+package com.icc.qasker.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CreatedAt {
+
+    @CreatedDate
+    private LocalDateTime createdAt;

--- a/src/main/java/com/icc/qasker/quiz/entity/Explanation.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/Explanation.java
@@ -1,12 +1,7 @@
 package com.icc.qasker.quiz.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
+import com.icc.qasker.global.entity.CreatedAt;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,7 +10,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @Setter
-public class Explanation {
+public class Explanation extends CreatedAt {
 
     @EmbeddedId
     private ProblemId id;
@@ -25,8 +20,8 @@ public class Explanation {
     @OneToOne
     @MapsId
     @JoinColumns({
-        @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
-        @JoinColumn(name = "number", referencedColumnName = "number")
+            @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
+            @JoinColumn(name = "number", referencedColumnName = "number")
     })
     private Problem problem;
 }

--- a/src/main/java/com/icc/qasker/quiz/entity/Problem.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/Problem.java
@@ -1,28 +1,21 @@
 package com.icc.qasker.quiz.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import java.util.ArrayList;
-import java.util.List;
+import com.icc.qasker.global.entity.CreatedAt;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @Setter
 @NoArgsConstructor
-public class Problem {
+public class Problem extends CreatedAt {
 
     @EmbeddedId
     private ProblemId id;

--- a/src/main/java/com/icc/qasker/quiz/entity/ProblemSet.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/ProblemSet.java
@@ -1,7 +1,11 @@
 package com.icc.qasker.quiz.entity;
 
+import com.icc.qasker.global.entity.CreatedAt;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -10,8 +14,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Setter
-public class ProblemSet {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+public class ProblemSet extends CreatedAt {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
 

--- a/src/main/java/com/icc/qasker/quiz/entity/ReferencedPage.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/ReferencedPage.java
@@ -1,5 +1,6 @@
 package com.icc.qasker.quiz.entity;
 
+import com.icc.qasker.global.entity.CreatedAt;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,7 +8,7 @@ import lombok.Setter;
 @Setter
 @Getter
 @Entity
-public class ReferencedPage {
+public class ReferencedPage extends CreatedAt {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/icc/qasker/quiz/entity/Selection.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/Selection.java
@@ -1,14 +1,7 @@
 package com.icc.qasker.quiz.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
-import jakarta.persistence.ManyToOne;
+import com.icc.qasker.global.entity.CreatedAt;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Setter
 @AllArgsConstructor
-public class Selection {
+public class Selection extends CreatedAt {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,8 +24,8 @@ public class Selection {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns({
-        @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
-        @JoinColumn(name = "number", referencedColumnName = "number")
+            @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
+            @JoinColumn(name = "number", referencedColumnName = "number")
     })
     private Problem problem;
 }


### PR DESCRIPTION
## 📢 설명
```java
package com.icc.qasker.global.entity;

import jakarta.persistence.Entity;
import jakarta.persistence.MappedSuperclass;
import org.springframework.data.annotation.CreatedDate;
import org.springframework.data.jpa.domain.support.AuditingEntityListener;
import jakarta.persistence.EntityListeners;

import java.time.LocalDateTime;

/**
 * 생성 시간을 관리하는 추상 클래스입니다.
 * 이 클래스를 상속하는 엔티티는 생성 시간이 자동으로 기록됩니다.
 */
@MappedSuperclass // 테이블로 매핑하지 않고, 자식 클래스에게 매핑 정보만 상속하도록 설정합니다.
@EntityListeners(AuditingEntityListener.class) // JPA Auditing 기능을 활성화합니다.
public abstract class CreatedAt {

    @CreatedDate // 엔티티가 생성될 때의 시간이 자동으로 저장됩니다.
    private LocalDateTime createdAt; // MySQL의 TIMESTAMP 타입과 매핑되는 Java의 LocalDateTime 타입입니다.

    public LocalDateTime getCreatedAt() {
        return createdAt;
    }
}
```

### 주요 변경 및 설명

  * **`abstract class`**: 다른 엔티티에서 상속하여 사용하도록 추상 클래스로 변경했습니다. 특정 테이블로 매핑되지 않도록 `@Entity` 대신 `@MappedSuperclass`를 사용했습니다.
  * **`LocalDateTime`**: MySQL의 `TIMESTAMP` 또는 `DATETIME` 타입에 가장 적합한 Java 8+의 시간 타입입니다.
  * **`@MappedSuperclass`**: 이 어노테이션을 사용하면 이 클래스는 테이블로 생성되지 않고, 이 클래스를 상속받는 자식 엔티티에게 필드(`createdAt`)만을 상속해주게 됩니다. 공통 필드를 관리하기에 매우 유용합니다.
  * **`@EntityListeners(AuditingEntityListener.class)`**: `@CreatedDate`와 같은 JPA Auditing 기능이 동작하도록 리스너를 추가해야 합니다.
  * **`private LocalDateTime createdAt;`**: `createdAt`이라는 이름의 필드를 선언하고, 엔티티 생성 시 자동으로 시간이 기록되도록 `@CreatedDate` 어노테이션을 붙였습니다.

### 사용 예시

`CreatedAt` 클래스를 상속받아 아래와 같이 `Post` 엔티티를 만들 수 있습니다.

```java
package com.icc.qasker.domain.post.entity;

import com.icc.qasker.global.entity.CreatedAt;
import jakarta.persistence.Entity;
import jakarta.persistence.GeneratedValue;
import jakarta.persistence.GenerationType;
import jakarta.persistence.Id;

@Entity
public class Post extends CreatedAt { // CreatedAt 클래스를 상속받습니다.

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    private String title;
    private String content;

    // Post 엔티티를 저장하면 createdAt 필드에 자동으로 생성 시간이 기록됩니다.
}
```

**중요**: JPA Auditing 기능을 사용하려면 애플리케이션의 메인 클래스나 설정 클래스에 `@EnableJpaAuditing` 어노테이션을 추가해야 합니다.

```java
import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

@SpringBootApplication
@EnableJpaAuditing // JPA Auditing 활성화
public class QaskerApplication {

    public static void main(String[] args) {
        SpringApplication.run(QaskerApplication.class, args);
    }

}
```
### 코드 설명: 코멘트 확인

## ✅ 체크 리스트

- [ ] 리뷰어가 체크할 내용을 작성해주세요!