### PR TITLE
[ICC-142] 리프레시 토큰만 발급하게 수정

### DIFF
--- a/src/main/java/com/icc/qasker/auth/utils/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/icc/qasker/auth/utils/OAuth2LoginSuccessHandler.java
@@ -1,10 +1,8 @@
 package com.icc.qasker.auth.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icc.qasker.auth.dto.principal.PrincipalDetails;
 import com.icc.qasker.auth.entity.User;
 import com.icc.qasker.auth.service.TokenRotationService;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,17 +17,16 @@ import org.springframework.stereotype.Component;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final TokenRotationService tokenRotationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     @Value("${q-asker.frontend-deploy-url}")
     private String frontendDeployUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException, ServletException {
+        Authentication authentication) throws IOException {
 
         PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
         User user = principal.getUser();
-        tokenRotationService.issueTokens(user.getUserId(), response);
+        tokenRotationService.issueRefreshToken(user.getUserId(), response);
         response.sendRedirect(frontendDeployUrl);
     }
 }


### PR DESCRIPTION
## 📢 설명
OAuth2 로그인 성공 시에는 리프레시 토큰만 발급하게 하였습니다
어짜피 액세스 토큰은 클라이언트가 볼 수 없기 때문입니다

### 코드 설명: 코멘트 확인

## ✅ 체크 리스트
- [x] 개발자 도구 켜기
- [x] http://localhost:8080/oauth2/authorization/google 이동
- [x] 로그인 후 http://localhost:5173 이동 확인
- [x] 개발자 도구에서 아래와 같은 요청 정보 찾아서 ```Authorization``` 헤더 없는지, ```Set-Cookie: refresh_token=...``` 헤더는 있는 지 확인
<img width="139" height="23" alt="image" src="https://github.com/user-attachments/assets/8a89e26c-29aa-4ced-aa63-9c8c9f2ca814" />