### PR TITLE
[ICC-152] 레디스 설정 책임 분리

### DIFF
--- a/src/main/java/com/icc/qasker/QAskerApplication.java
+++ b/src/main/java/com/icc/qasker/QAskerApplication.java
@@ -1,11 +1,14 @@
 package com.icc.qasker;
 
+import com.icc.qasker.auth.config.RedisProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableConfigurationProperties(RedisProperties.class)
 public class QAskerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/icc/qasker/auth/config/RedisConfig.java
+++ b/src/main/java/com/icc/qasker/auth/config/RedisConfig.java
@@ -1,35 +1,23 @@
 package com.icc.qasker.auth.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
+    private final RedisProperties redisProperties;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
-
-    @Value("${spring.data.redis.database}")
-    private int database;
+    @Autowired
+    public RedisConfig(RedisProperties redisProperties) {
+        this.redisProperties = redisProperties;
+    }
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(host);
-        config.setPort(port);
-        config.setPassword(password);
-        config.setDatabase(database);
-
-        return new LettuceConnectionFactory(config);
+        return new LettuceConnectionFactory(redisProperties.getRedisConfiguration());
     }
 }

--- a/src/main/java/com/icc/qasker/auth/config/RedisProperties.java
+++ b/src/main/java/com/icc/qasker/auth/config/RedisProperties.java
@@ -1,0 +1,31 @@
+package com.icc.qasker.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.redis.connection.RedisConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+@Getter
+@Setter
+public class RedisProperties {
+
+    private String host;
+    private int port;
+    private String password;
+    private int database;
+
+    public RedisConfiguration getRedisConfiguration() {
+
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setPassword(password);
+        config.setDatabase(database);
+
+        return config;
+    }
+
+
+}


### PR DESCRIPTION
## 📢 설명

1. @EnableConfigurationProperties(RedisProperties.class)를 통해 RedisProperties.class는 EnableConfigurationPropertiesRegistrar의 관리 대상이 됩니다. 동시에 Bean 설계도를 만들어 스프링 IoC 컨테이너에게 제출합니다
2. 스프링 IoC 컨테이너가 Bean을만들 시점에 @ConfigurationProperties(prefix = "spring.data.redis") 메타데이터를 통해 spring.data.redis에 존재하는 하위 key-value들을 가져와 RedisProperties의 각 속성에 매핑합니다. 이때 Setter를 이용합니다
3. 스프링이 RedisProperties를 RedisConfig에 의존성 주입해주고 redisProperties.getRedisConfiguration()를 호출해서 RedisConfiguration를 얻기만하면 됩니다.

환경변수를 가져오는 책임을 분리했고 @Value에 일일이 지정해주지 않아도 되는 유지보수성을 얻고 
파일이 하나 더 늘어나는 것을 잃었습니다

### 코드 설명: 코멘트 확인

## ✅ 체크 리스트

- [ ] 코드리뷰