### PR TITLE
[ICC-273] Transactional Outbox 기반 게시글 이벤트 Kafka 발행

### DIFF
--- a/app/src/main/java/com/icc/qasker/QAskerApplication.java
+++ b/app/src/main/java/com/icc/qasker/QAskerApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan("com.icc.qasker")
 @EnableCaching
+@EnableScheduling
 public class QAskerApplication {
 
   public static void main(String[] args) {

--- a/modules/board/api/src/main/java/com/icc/qasker/board/event/BoardEventPayload.java
+++ b/modules/board/api/src/main/java/com/icc/qasker/board/event/BoardEventPayload.java
@@ -1,0 +1,6 @@
+package com.icc.qasker.board.event;
+
+import java.time.Instant;
+
+public record BoardEventPayload(
+    BoardEventType eventType, Long boardId, String userId, String title, Instant occurredAt) {}

--- a/modules/board/api/src/main/java/com/icc/qasker/board/event/BoardEventType.java
+++ b/modules/board/api/src/main/java/com/icc/qasker/board/event/BoardEventType.java
@@ -1,0 +1,7 @@
+package com.icc.qasker.board.event;
+
+public enum BoardEventType {
+  POST_CREATED,
+  POST_UPDATED,
+  POST_DELETED
+}

--- a/modules/board/impl/src/main/java/com/icc/qasker/board/entity/BoardEventOutbox.java
+++ b/modules/board/impl/src/main/java/com/icc/qasker/board/entity/BoardEventOutbox.java
@@ -1,0 +1,54 @@
+package com.icc.qasker.board.entity;
+
+import com.icc.qasker.board.event.BoardEventType;
+import com.icc.qasker.global.entity.CreatedAt;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "board_event_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardEventOutbox extends CreatedAt {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long boardId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private BoardEventType eventType;
+
+  @Lob
+  @Column(nullable = false)
+  private String payload;
+
+  @Column(nullable = false)
+  private boolean published;
+
+  @Builder
+  public BoardEventOutbox(Long boardId, BoardEventType eventType, String payload) {
+    this.boardId = boardId;
+    this.eventType = eventType;
+    this.payload = payload;
+    this.published = false;
+  }
+
+  public void markPublished() {
+    this.published = true;
+  }
+}

--- a/modules/board/impl/src/main/java/com/icc/qasker/board/kafka/BoardKafkaProducer.java
+++ b/modules/board/impl/src/main/java/com/icc/qasker/board/kafka/BoardKafkaProducer.java
@@ -1,0 +1,18 @@
+package com.icc.qasker.board.kafka;
+
+import com.icc.qasker.board.event.BoardEventPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BoardKafkaProducer {
+
+  private static final String TOPIC = "board-events";
+  private final KafkaTemplate<String, BoardEventPayload> kafkaTemplate;
+
+  public void send(BoardEventPayload payload) {
+    kafkaTemplate.send(TOPIC, payload);
+  }
+}

--- a/modules/board/impl/src/main/java/com/icc/qasker/board/repository/BoardEventOutboxRepository.java
+++ b/modules/board/impl/src/main/java/com/icc/qasker/board/repository/BoardEventOutboxRepository.java
@@ -1,0 +1,10 @@
+package com.icc.qasker.board.repository;
+
+import com.icc.qasker.board.entity.BoardEventOutbox;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardEventOutboxRepository extends JpaRepository<BoardEventOutbox, Long> {
+
+  List<BoardEventOutbox> findAllByPublishedFalse();
+}

--- a/modules/board/impl/src/main/java/com/icc/qasker/board/service/BoardMessageRelayService.java
+++ b/modules/board/impl/src/main/java/com/icc/qasker/board/service/BoardMessageRelayService.java
@@ -1,0 +1,39 @@
+package com.icc.qasker.board.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icc.qasker.board.entity.BoardEventOutbox;
+import com.icc.qasker.board.event.BoardEventPayload;
+import com.icc.qasker.board.kafka.BoardKafkaProducer;
+import com.icc.qasker.board.repository.BoardEventOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardMessageRelayService {
+
+  private final BoardEventOutboxRepository outboxRepository;
+  private final BoardKafkaProducer kafkaProducer;
+  private final ObjectMapper objectMapper;
+
+  @Scheduled(fixedDelay = 2000)
+  @Transactional
+  public void relay() {
+    List<BoardEventOutbox> pending = outboxRepository.findAllByPublishedFalse();
+    for (BoardEventOutbox outbox : pending) {
+      try {
+        BoardEventPayload payload =
+            objectMapper.readValue(outbox.getPayload(), BoardEventPayload.class);
+        kafkaProducer.send(payload);
+        outbox.markPublished();
+      } catch (Exception e) {
+        log.error("Kafka 발행 실패 - outboxId: {}", outbox.getId(), e);
+      }
+    }
+  }
+}

--- a/modules/board/impl/src/main/java/com/icc/qasker/board/service/BoardService.java
+++ b/modules/board/impl/src/main/java/com/icc/qasker/board/service/BoardService.java
@@ -1,20 +1,27 @@
 package com.icc.qasker.board.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icc.qasker.auth.UserService;
 import com.icc.qasker.board.dto.request.PostRequest;
 import com.icc.qasker.board.dto.response.PostDetailResponse;
 import com.icc.qasker.board.dto.response.PostResponse;
 import com.icc.qasker.board.entity.Board;
+import com.icc.qasker.board.entity.BoardEventOutbox;
 import com.icc.qasker.board.entity.BoardStatus;
 import com.icc.qasker.board.entity.Reply;
+import com.icc.qasker.board.event.BoardEventPayload;
+import com.icc.qasker.board.event.BoardEventType;
 import com.icc.qasker.board.mapper.PostResponseMapper;
+import com.icc.qasker.board.repository.BoardEventOutboxRepository;
 import com.icc.qasker.board.repository.BoardRepository;
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,12 +29,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class BoardService {
 
   private final BoardRepository boardRepository;
+  private final BoardEventOutboxRepository outboxRepository;
   private final PostResponseMapper postResponseMapper;
   private final UserService userService;
+  private final ObjectMapper objectMapper;
 
   public Page<PostResponse> getPosts(Pageable pageable) {
     Page<Board> boards = boardRepository.findAll(pageable);
@@ -75,6 +85,7 @@ public class BoardService {
     Board board =
         Board.builder().title(request.title()).content(request.content()).userId(userId).build();
     boardRepository.save(board);
+    saveOutbox(board.getBoardId(), userId, request.title(), BoardEventType.POST_CREATED);
   }
 
   @Transactional
@@ -96,6 +107,7 @@ public class BoardService {
       throw new CustomException(ExceptionMessage.NOT_ENOUGH_ACCESS);
     }
     board.update(request.title(), request.content());
+    saveOutbox(boardId, userId, request.title(), BoardEventType.POST_UPDATED);
   }
 
   @Transactional
@@ -115,5 +127,18 @@ public class BoardService {
       throw new CustomException(ExceptionMessage.NOT_ENOUGH_ACCESS);
     }
     board.changeStatus(BoardStatus.DELETED);
+    saveOutbox(boardId, userId, board.getTitle(), BoardEventType.POST_DELETED);
+  }
+
+  private void saveOutbox(Long boardId, String userId, String title, BoardEventType eventType) {
+    try {
+      BoardEventPayload payload =
+          new BoardEventPayload(eventType, boardId, userId, title, Instant.now());
+      String json = objectMapper.writeValueAsString(payload);
+      outboxRepository.save(
+          BoardEventOutbox.builder().boardId(boardId).eventType(eventType).payload(json).build());
+    } catch (Exception e) {
+      log.error("Outbox 저장 실패 - boardId: {}, eventType: {}", boardId, eventType, e);
+    }
   }
 }


### PR DESCRIPTION
 ## 📢 설명

  > 게시글 CUD 이벤트를 Kafka로 안정적으로 발행하기 위한 Transactional Outbox 패턴 구현

  ### 변경 요약

  | # | 변경 | 설명 | 영향 범위 |
  |---|------|------|-----------|
  | 1 | Transactional Outbox 인프라 | `BoardEventOutbox` 엔티티, Repository, enum, DTO 추가 | board-api, board-impl |
  | 2 | Kafka Producer 설정 | `BoardKafkaProducer` + Producer 설정 (`acks=all`, `enable-idempotence`, `JsonSerializer`) | board-impl, application-local.yml |
  | 3 | BoardService CUD 연동 + Message Relay | CUD 메서드에 Outbox INSERT, 2초 주기 스케줄러로 Kafka 발행 | board-impl, app |

  ---

  ### 변경 1: Transactional Outbox 인프라

  게시글 저장과 Kafka 발행 사이의 **dual-write 문제**를 해결하기 위해 Transactional Outbox 패턴을 도입했다. Slack 알림 등 외부 시스템과 높은 의존도를 갖지 않도록 Kafka를 통해 느슨하게 연동한다.        

  - `BoardEventType` enum: `POST_CREATED`, `POST_UPDATED`, `POST_DELETED`
  - `BoardEventPayload` record: Kafka 메시지 페이로드 DTO (board-api에 위치하여 Consumer도 참조 가능)
  - `BoardEventOutbox` 엔티티: DB에 저장하는 발송 대기열. `published` 필드로 발행 여부 관리
  - `BoardEventOutboxRepository`: `findAllByPublishedFalse()`로 미발행 이벤트 조회

  게시글 저장 + Outbox INSERT를 **같은 DB 트랜잭션**으로 묶어 원자성을 보장한다. 서버가 중간에 죽어도 `published=false` 행이 DB에 남아있으므로 재시작 후 재발행된다.

  ---

  ### 변경 2: Kafka Producer 설정

  `KafkaTemplate<String, BoardEventPayload>`로 `board-events` 토픽에 메시지를 발행하는 `BoardKafkaProducer`를 구현했다.

  Outbox 패턴은 **at-least-once 보장**이 본질이므로, 메시지 유실보다 중복이 낫다는 전제에서 Producer 설정을 구성했다:

  | 설정 | 값 | 근거 |
  |------|-----|------|
  | `acks` | `all` | 모든 ISR이 메시지를 받아야 ack 반환. 브로커 1대가 죽어도 메시지 유실 방지 |
  | `enable-idempotence` | `true` | 네트워크 오류로 Producer가 같은 메시지를 재전송해도 Broker가 중복 감지하여 1번만 저장. `acks=all` + `retries>0` 자동 강제 |
  | `retries` | `3` | 일시적 브로커 장애(리더 선출 등) 시 재시도. `enable-idempotence`와 함께 쓰면 재시도해도 중복 없음 |
  | `value-serializer` | `JsonSerializer` | `BoardEventPayload` DTO를 직접 발행하여 타입 안전성 확보 |
  | `key-serializer` | `StringSerializer` | Key는 파티션 라우팅 용도이므로 JSON 불필요 |

  > [!NOTE]
  > `enable-idempotence`는 **Producer↔Broker 간 중복만 방지**한다. Relay가 Kafka 발행 성공 후 `published=true` 업데이트에 실패하면 다음 주기에 같은 메시지가 재발행되므로, Consumer 측에서 멱등하게 처리해야 한다.

  ---

  ### 변경 3: BoardService CUD 연동 + Message Relay 스케줄러

  `BoardService`의 `createPost`/`updatePost`/`deletePost`에 같은 트랜잭션 내에서 Outbox INSERT를 추가했다. `BoardMessageRelayService`가 `@Scheduled(fixedDelay = 2000)`으로 2초 주기 폴링하여 미발행     
  이벤트를 Kafka에 발행한다.

  **설계 결정:**

  - **`saveOutbox` 실패 시 로그만 기록**: Outbox 저장 실패(JSON 직렬화 오류 등)가 게시글 작성 자체를 실패시키면 안 된다. 이벤트 알림 누락일 뿐 핵심 비즈니스 로직에 영향을 주지 않는다.
  - **Relay에서 `send()` 실패 시 해당 건만 skip**: 전체 트랜잭션 롤백 대신 실패한 건만 다음 주기에 재시도한다. 전체 롤백하면 이미 성공한 발행도 재시도되어 불필요한 중복이 발생한다.

  ### 코드 설명: 인라인 코멘트

  > PR의 주요 코드 라인에 인라인 코멘트가 등록되어 있습니다. Files changed 탭에서 확인하세요.

  ## ✅ 체크리스트

  ### 재현 확인

  - [ ] Kafka 브로커 기동 후 게시글 CUD → `board-events` 토픽 메시지 발행 확인 (추후)

  ### 기본

  - [ ] 의사 선택 과정이 적절한지 확인
  - [ ] 코드 리뷰
