### PR TITLE
v 3.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 group = "com.icc.qasker"
 // 프로젝트 버전 (Docker 이미지 태그, 배포 아티팩트 버전에 사용)
 // 예: jib으로 빌드하면 Docker 이미지에 "1.7.0" 태그가 붙음
-version = "3.1.0"
+version = "3.1.2"
 
 // Git hooks 경로를 .githooks/로 자동 설정
 // 예: ./gradlew build 실행 시 자동으로 git config core.hooksPath .githooks 적용

--- a/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/EssayGradingServiceImpl.java
+++ b/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/EssayGradingServiceImpl.java
@@ -103,7 +103,7 @@ public class EssayGradingServiceImpl implements EssayGradingService {
               gradingOnly.elementScores(),
               gradingOnly.totalScore(),
               gradingOnly.maxScore(),
-              gradingOnly.overallFeedback(),
+              composeOverallFeedback(attemptCount, modelAnswer, gradingOnly.overallFeedback()),
               evJson);
       log.info(
           "ESSAY 채점 완료 (2-pass): 총점={}/{}, 소요={}ms, 토큰: 입력={}, 출력={}, 비용=${}",
@@ -157,7 +157,7 @@ public class EssayGradingServiceImpl implements EssayGradingService {
     UserMessage userMessage =
         new UserMessage(
             EssayGradingRequestPrompt.generateWithEvidence(
-                question, modelAnswer, rubric, evidence, attemptCount));
+                question, modelAnswer, rubric, evidence));
 
     var options =
         GoogleGenAiChatOptions.builder()
@@ -186,8 +186,7 @@ public class EssayGradingServiceImpl implements EssayGradingService {
     SystemMessage systemMessage = new SystemMessage(EssayGradingGuideLine.of(attemptCount));
     UserMessage userMessage =
         new UserMessage(
-            EssayGradingRequestPrompt.generate(
-                question, modelAnswer, rubric, studentAnswer, attemptCount));
+            EssayGradingRequestPrompt.generate(question, modelAnswer, rubric, studentAnswer));
 
     var options =
         GoogleGenAiChatOptions.builder()
@@ -208,7 +207,14 @@ public class EssayGradingServiceImpl implements EssayGradingService {
             + outputTokens * PRICE_OUTPUT_PER_1M / 1_000_000;
     metricsRecorder.recordGrading(elapsedMs, nonCachedInput, outputTokens, cost);
 
-    EssayGradingResult result = parseGradingResponse(responseText);
+    EssayGradingResult parsed = parseGradingResponse(responseText);
+    EssayGradingResult result =
+        new EssayGradingResult(
+            parsed.elementScores(),
+            parsed.totalScore(),
+            parsed.maxScore(),
+            composeOverallFeedback(attemptCount, modelAnswer, parsed.overallFeedback()),
+            parsed.evidenceJson());
 
     log.info(
         "ESSAY 채점 완료 (fallback 1-pass): 총점={}/{}, 소요={}ms",
@@ -254,5 +260,15 @@ public class EssayGradingServiceImpl implements EssayGradingService {
       log.warn("[채점 직렬화 실패] 증거 JSON 직렬화 실패", e);
       return null;
     }
+  }
+
+  /** LLM이 작성한 종합 평가 앞에 항상 `## 힌트` 헤더를 붙이고, 시도 3차 이상에서는 그 뒤에 `## 모범답안` 헤더와 모범답안 본문을 첨부한다. */
+  private static String composeOverallFeedback(
+      int attemptCount, String modelAnswer, String llmOverallFeedback) {
+    String hintSection = "## 힌트\n\n" + llmOverallFeedback;
+    if (attemptCount < 3) {
+      return hintSection;
+    }
+    return hintSection + "\n\n## 모범답안\n\n" + modelAnswer;
   }
 }

--- a/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/prompt/EssayGradingGuideLine.java
+++ b/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/prompt/EssayGradingGuideLine.java
@@ -37,21 +37,8 @@ public class EssayGradingGuideLine {
       - maxScore는 각 요소의 maxPoints 합계입니다. 루브릭의 배점 합계와 반드시 일치해야 합니다.
       """;
 
-  // 1차 시도: 경미한 힌트만 제공 (방향성만, 정답 키워드 노출 금지)
+  // 1차 시도: 구체적 안내 (모범답안 키워드 노출 금지)
   private static final String FEEDBACK_ATTEMPT_1 =
-      """
-
-      ## 3. 피드백 원칙 (경미한 힌트만 제시)
-      - 각 요소별 feedback은 **1문장 이내의 짧은 방향성 힌트**로만 작성합니다.
-      - **충족**: 잘 작성된 점을 한 문장으로 짧게 인정합니다. (예: "핵심을 잘 짚었어요.")
-      - **부분 충족**: 어떤 부분을 더 보완해야 하는지 **개략적 방향만** 한 문장으로 제시합니다. 구체적 키워드·표현·정답 내용은 노출하지 마세요. (예: "이 개념의 작동 원리를 한 단계 더 풀어 써 보세요.")
-      - **미충족**: 해당 요소를 답안에서 다루지 않았음을 짧게 알리고, 다시 생각해볼 수 있도록 가볍게 유도합니다. (예: "이 요소가 답안에 거의 드러나지 않아요. 강의노트의 관련 부분을 다시 살펴보세요.")
-      - 종합 피드백(overallFeedback)은 **빈 문자열("")**로 둡니다.
-      - 모범답안에 등장하는 구체 용어·수치·핵심 키워드를 직접 노출하지 마세요. 1차 시도는 **'다시 생각해보게 하는 가벼운 푸시'** 수준에 머물러야 합니다.
-      """;
-
-  // 2차 시도: 구체적 안내
-  private static final String FEEDBACK_ATTEMPT_2 =
       """
 
       ## 3. 피드백 원칙 (구체적 안내)
@@ -63,8 +50,8 @@ public class EssayGradingGuideLine {
       - overallFeedback은 잘한 점 → 부족한 점 → 개선 방향 순서로 작성합니다.
       """;
 
-  // 3~4차 시도: 모범답안 힌트 포함
-  private static final String FEEDBACK_ATTEMPT_3 =
+  // 2차 시도 이상: 정답 근접 가이드 (모범답안 핵심 키워드 힌트로 노출)
+  private static final String FEEDBACK_ATTEMPT_2 =
       """
 
       ## 3. 피드백 원칙 (정답 근접 가이드)
@@ -86,12 +73,7 @@ public class EssayGradingGuideLine {
 
   /** 시도 횟수에 따라 피드백 수준이 차등 적용된 시스템 프롬프트를 반환한다. */
   public static String of(int attemptCount) {
-    String feedbackSection =
-        switch (attemptCount) {
-          case 1 -> FEEDBACK_ATTEMPT_1;
-          case 2 -> FEEDBACK_ATTEMPT_2;
-          default -> FEEDBACK_ATTEMPT_3;
-        };
+    String feedbackSection = attemptCount == 1 ? FEEDBACK_ATTEMPT_1 : FEEDBACK_ATTEMPT_2;
     return COMMON_PREFIX + feedbackSection + COMMON_SUFFIX;
   }
 }

--- a/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/prompt/EssayGradingRequestPrompt.java
+++ b/modules/quiz-ai/impl/src/main/java/com/icc/qasker/ai/service/essay/prompt/EssayGradingRequestPrompt.java
@@ -8,23 +8,22 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EssayGradingRequestPrompt {
 
+  private static final String INSTRUCTION = "위 분석적 루브릭의 각 요소별로 채점하고, 요소별 피드백과 종합 피드백을 작성하세요.";
+
+  private static final String INSTRUCTION_WITH_EVIDENCE =
+      "위 분석적 루브릭의 각 요소별로, 추출된 증거에 근거하여 채점하고, 요소별 피드백과 종합 피드백을 작성하세요.";
+
   /**
-   * 채점 유저 프롬프트를 생성한다.
+   * 채점 유저 프롬프트를 생성한다. (1-pass fallback용)
    *
    * @param question 질문문
    * @param modelAnswer 모범답안 (핵심 요소 포함)
    * @param rubric 분석적 루브릭 (explanation 필드에서 추출)
    * @param studentAnswer 학생이 제출한 답안
-   * @param attemptCount 시도 횟수 (1차: 채점만, 2차+: 피드백 포함)
    * @return 조합된 유저 프롬프트
    */
   public static String generate(
-      String question, String modelAnswer, String rubric, String studentAnswer, int attemptCount) {
-    String instruction =
-        attemptCount == 1
-            ? "위 분석적 루브릭의 각 요소별로 채점하고, 요소별 feedback은 경미한 방향성 힌트(1문장 이내)만 작성하세요. overallFeedback은 빈 문자열로 둡니다."
-            : "위 분석적 루브릭의 각 요소별로 채점하고, 요소별 피드백과 종합 피드백을 작성하세요.";
-
+      String question, String modelAnswer, String rubric, String studentAnswer) {
     return """
         [채점 요청]
         아래의 질문문, 모범답안, 분석적 루브릭, 학생 답안을 참고하여 채점하세요.
@@ -52,7 +51,7 @@ public class EssayGradingRequestPrompt {
         ---
 
         %s"""
-        .formatted(question, modelAnswer, rubric, studentAnswer, instruction);
+        .formatted(question, modelAnswer, rubric, studentAnswer, INSTRUCTION);
   }
 
   /**
@@ -62,20 +61,13 @@ public class EssayGradingRequestPrompt {
    * @param modelAnswer 모범답안
    * @param rubric 분석적 루브릭
    * @param evidence Pass 1에서 추출된 증거
-   * @param attemptCount 시도 횟수
    * @return 조합된 유저 프롬프트
    */
   public static String generateWithEvidence(
       String question,
       String modelAnswer,
       String rubric,
-      GeminiEvidenceExtractionResponse evidence,
-      int attemptCount) {
-    String instruction =
-        attemptCount == 1
-            ? "위 분석적 루브릭의 각 요소별로, 추출된 증거에 근거하여 채점하고, 요소별 feedback은 경미한 방향성 힌트(1문장 이내)만 작성하세요. overallFeedback은 빈 문자열로 둡니다."
-            : "위 분석적 루브릭의 각 요소별로, 추출된 증거에 근거하여 채점하고, 요소별 피드백과 종합 피드백을 작성하세요.";
-
+      GeminiEvidenceExtractionResponse evidence) {
     StringBuilder evidenceSection = new StringBuilder();
     for (var e : evidence.elements()) {
       evidenceSection.append("### ").append(e.element()).append("\n");
@@ -117,6 +109,7 @@ public class EssayGradingRequestPrompt {
         ---
 
         %s"""
-        .formatted(question, modelAnswer, rubric, evidenceSection.toString(), instruction);
+        .formatted(
+            question, modelAnswer, rubric, evidenceSection.toString(), INSTRUCTION_WITH_EVIDENCE);
   }
 }


### PR DESCRIPTION
- 시스템 프롬프트를 1차(구체적 안내) / 2차+(정답 근접 가이드) 2단계로 단순화
- EssayGradingRequestPrompt에서 미사용 attemptCount 파라미터 제거
- composeOverallFeedback 헬퍼로 overallFeedback 앞에 항상 '## 힌트' 헤더 prepend, 3차 이상에서는 '## 모범답안' 헤더와 DB의 모범답안 본문을 append

<!-- prettier-ignore-start -->

## 📢 설명

### 변경 1: [제목]

[변경에 대한 설명]

#### 의사 선택과정 (trade-off)

> trade-off가 있는 경우에만 작성

**얻은 것**
-

**잃은 것**
-

### 코드 설명: 인라인 코멘트 확인

## ✅ 체크 리스트

### 재현 확인

<!-- 리뷰어가 직접 따라하며 변경사항을 확인할 수 있는 단계 -->

- [ ] (PR 작성 시 채워주세요)

### 기본

- [ ] 의사 선택 과정이 적절한지 확인
- [ ] 코드 리뷰

---
<!-- prettier-ignore-end -->
