### PR TITLE
fix: ESSAY 채점 모델명 교정 (404 핫픽스)

### DIFF
--- a/app/src/main/resources/config/ai-setting.yml
+++ b/app/src/main/resources/config/ai-setting.yml
@@ -43,7 +43,7 @@ q-asker:
     multiple:
       chunk-mode: 1  # 1: 단일 호출, 2: 멀티턴 순차 (A→B→C 중복방지), 3: 패턴별 병렬 (A/B/C)
     essay:
-      grading-model: gemini-3.1-flash-lite-preview
+      grading-model: gemini-3.1-flash-lite
       # 채점 모델 토큰 단가 (USD per 1M tokens)
       price-input-per-1m: 0.25
       price-output-per-1m: 1.50


### PR DESCRIPTION
## 문제

프로덕션에서 ESSAY 채점 요청이 전량 실패(HTTP 500)하고 있었다.

```
com.google.genai.errors.ClientException: 404 .
Publisher model `.../models/gemini-3.1-flash-lite-preview` was not found
or your project does not have access to it.
```

- `EssayGradingServiceImpl`의 바깥 catch가 이 404를 `GeminiInfraException("ESSAY 채점 AI 호출 실패")`로 감싸 500으로 노출.
- Pass 1 실패 시 `fallbackSinglePass`도 **같은 모델**을 쓰므로 fallback도 동일하게 404 → 모든 채점이 100% 실패.
- 일시 장애가 아니라 **설정(모델명) 오류**.

## 변경

`app/src/main/resources/config/ai-setting.yml` 한 줄:

```
grading-model: gemini-3.1-flash-lite-preview  →  gemini-3.1-flash-lite
```

존재하지 않는 preview 모델명을 GA 모델명으로 교정한다. 그 외 변경 없음(ICC-332 작업과 분리한 핫픽스).

## 확인

- [ ] `gemini-3.1-flash-lite`가 해당 GCP 프로젝트/리전(`global`)에서 실제 접근 가능한 모델명인지 배포 전 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)