### PR TITLE
[ICC-348] feat(quiz-history): 퀴즈 기록 폴더 분류 기능

### DIFF
--- a/app/src/main/resources/db/migration/V16__add_quiz_folder.sql
+++ b/app/src/main/resources/db/migration/V16__add_quiz_folder.sql
@@ -1,0 +1,15 @@
+-- V16: 퀴즈 기록 폴더 분류
+-- 사용자가 자기 기록을 묶는 명명된 폴더(quiz_folder)를 두고,
+-- quiz_history.folder_id(nullable FK 컬럼)로 단일 소속을 표현한다. NULL = 미분류.
+CREATE TABLE quiz_folder
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id    VARCHAR(255) NOT NULL,
+    name       VARCHAR(50)  NOT NULL,
+    created_at DATETIME(6)  NOT NULL,
+    INDEX idx_quiz_folder_user (user_id)
+);
+
+ALTER TABLE quiz_history
+    ADD COLUMN folder_id BIGINT NULL,
+    ADD INDEX idx_quiz_history_user_folder (user_id, folder_id);

--- a/modules/auth/impl/src/main/java/com/icc/qasker/auth/config/SecurityConfig.java
+++ b/modules/auth/impl/src/main/java/com/icc/qasker/auth/config/SecurityConfig.java
@@ -75,6 +75,8 @@ public class SecurityConfig {
                     .authenticated()
                     .requestMatchers("/history", "/history/**")
                     .authenticated()
+                    .requestMatchers("/folders", "/folders/**")
+                    .authenticated()
                     .requestMatchers(HttpMethod.PATCH, "/problem-set/*/title")
                     .authenticated()
                     .anyRequest()

--- a/modules/global/src/main/java/com/icc/qasker/global/error/CustomErrorResponse.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/error/CustomErrorResponse.java
@@ -1,11 +1,23 @@
 package com.icc.qasker.global.error;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CustomErrorResponse {
 
-  private String message;
+  // 안정적 오류 식별 코드. null이면 응답 body에서 생략(기존 응답 하위호환).
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String code;
+
+  private final String message;
+
+  public CustomErrorResponse(String message) {
+    this(null, message);
+  }
+
+  public CustomErrorResponse(String code, String message) {
+    this.code = code;
+    this.message = message;
+  }
 }

--- a/modules/global/src/main/java/com/icc/qasker/global/error/CustomException.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/error/CustomException.java
@@ -10,6 +10,9 @@ public class CustomException extends RuntimeException {
   private final String message;
   private final String context;
 
+  // 안정적 오류 식별 코드(ExceptionMessage 상수명). 동적 메시지 생성자에서는 null.
+  private final String code;
+
   // 기본 사용: 정의된 예외 메시지만으로 충분할 때
   // 예) throw new CustomException(ExceptionMessage.NOT_FOUND);
   // 로그) ERROR 해당 리소스를 찾을 수 없습니다
@@ -20,6 +23,7 @@ public class CustomException extends RuntimeException {
     this.httpStatus = exceptionMessage.getHttpStatus();
     this.message = exceptionMessage.getMessage();
     this.context = null;
+    this.code = exceptionMessage.name();
   }
 
   // 동적 메시지: 정의되지 않은 상태 코드와 메시지를 직접 지정할 때
@@ -32,6 +36,7 @@ public class CustomException extends RuntimeException {
     this.httpStatus = httpStatus;
     this.message = message;
     this.context = null;
+    this.code = null;
   }
 
   // 디버깅 컨텍스트 포함: 로그에 부가 정보(ID, 파라미터 등)를 남길 때
@@ -44,6 +49,7 @@ public class CustomException extends RuntimeException {
     this.httpStatus = exceptionMessage.getHttpStatus();
     this.message = exceptionMessage.getMessage();
     this.context = context;
+    this.code = exceptionMessage.name();
   }
 
   // 원인 체이닝: 외부 라이브러리 예외를 래핑하여 원인을 보존할 때
@@ -58,6 +64,7 @@ public class CustomException extends RuntimeException {
     this.httpStatus = exceptionMessage.getHttpStatus();
     this.message = exceptionMessage.getMessage();
     this.context = null;
+    this.code = exceptionMessage.name();
   }
 
   // 컨텍스트 + 원인 체이닝: 디버깅 정보와 원인 예외를 모두 보존할 때
@@ -73,5 +80,6 @@ public class CustomException extends RuntimeException {
     this.httpStatus = exceptionMessage.getHttpStatus();
     this.message = exceptionMessage.getMessage();
     this.context = context;
+    this.code = exceptionMessage.name();
   }
 }

--- a/modules/global/src/main/java/com/icc/qasker/global/error/ExceptionMessage.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/error/ExceptionMessage.java
@@ -30,6 +30,9 @@ public enum ExceptionMessage {
 
   // ## 퀴즈 히스토리 (quiz-history)
   QUIZ_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈 히스토리를 찾을 수 없습니다."),
+  FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "폴더를 찾을 수 없습니다."),
+  FOLDER_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "폴더는 최대 100개까지 만들 수 있습니다."),
+  FOLDER_NAME_INVALID(HttpStatus.BAD_REQUEST, "폴더 이름은 1자 이상 50자 이하여야 합니다."),
 
   // ## AI (quiz-ai, quiz-make)
   AI_SERVER_COMMUNICATION_ERROR(

--- a/modules/global/src/main/java/com/icc/qasker/global/error/GlobalExceptionHandler.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/error/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
     logCustomException(customException);
 
     return ResponseEntity.status(customException.getHttpStatus())
-        .body(new CustomErrorResponse(customException.getMessage()));
+        .body(new CustomErrorResponse(customException.getCode(), customException.getMessage()));
   }
 
   private void logCustomException(CustomException customException) {

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizFolderCommandService.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizFolderCommandService.java
@@ -1,0 +1,12 @@
+package com.icc.qasker.quizhistory;
+
+import com.icc.qasker.quizhistory.dto.feresponse.FolderResponse;
+
+public interface QuizFolderCommandService {
+
+  FolderResponse createFolder(String userId, String name);
+
+  void renameFolder(String userId, String folderId, String name);
+
+  void deleteFolder(String userId, String folderId);
+}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizFolderQueryService.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizFolderQueryService.java
@@ -1,0 +1,8 @@
+package com.icc.qasker.quizhistory;
+
+import com.icc.qasker.quizhistory.dto.feresponse.FolderListResponse;
+
+public interface QuizFolderQueryService {
+
+  FolderListResponse getFolders(String userId);
+}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizHistoryCommandService.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizHistoryCommandService.java
@@ -14,4 +14,6 @@ public interface QuizHistoryCommandService {
   void deleteHistory(String userId, String historyId);
 
   void updateHistoryTitle(String userId, String historyId, String title);
+
+  void assignFolder(String userId, String historyId, String folderId);
 }

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizHistoryQueryService.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/QuizHistoryQueryService.java
@@ -1,5 +1,6 @@
 package com.icc.qasker.quizhistory;
 
+import com.icc.qasker.quizhistory.dto.ferequest.HistoryScope;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryCheckResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryDetailResponse;
@@ -7,7 +8,8 @@ import com.icc.qasker.quizhistory.dto.feresponse.HistoryPageResponse;
 
 public interface QuizHistoryQueryService {
 
-  HistoryPageResponse getHistoryList(String userId, int page, int size);
+  HistoryPageResponse getHistoryList(
+      String userId, HistoryScope scope, String folderId, int page, int size);
 
   HistoryDetailResponse getHistoryDetail(String userId, String historyId);
 

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/AssignFolderRequest.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/AssignFolderRequest.java
@@ -1,0 +1,4 @@
+package com.icc.qasker.quizhistory.dto.ferequest;
+
+/** 기록을 폴더에 배정/해제. folderId가 null이면 미분류로 해제한다. */
+public record AssignFolderRequest(String folderId) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/CreateFolderRequest.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/CreateFolderRequest.java
@@ -1,0 +1,4 @@
+package com.icc.qasker.quizhistory.dto.ferequest;
+
+/** 폴더 생성 요청. 이름 검증(빈/공백/50자)은 서비스 계층에서 수행한다. */
+public record CreateFolderRequest(String name) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/HistoryScope.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/HistoryScope.java
@@ -1,0 +1,8 @@
+package com.icc.qasker.quizhistory.dto.ferequest;
+
+/** 히스토리 목록 탐색 범위. ALL=전체, UNCLASSIFIED=미분류, FOLDER=특정 폴더(folderId 필요). */
+public enum HistoryScope {
+  ALL,
+  UNCLASSIFIED,
+  FOLDER
+}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/RenameFolderRequest.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/ferequest/RenameFolderRequest.java
@@ -1,0 +1,4 @@
+package com.icc.qasker.quizhistory.dto.ferequest;
+
+/** 폴더 이름 변경 요청. 이름 검증(빈/공백/50자)은 서비스 계층에서 수행한다. */
+public record RenameFolderRequest(String name) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderListResponse.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderListResponse.java
@@ -1,0 +1,6 @@
+package com.icc.qasker.quizhistory.dto.feresponse;
+
+import java.util.List;
+
+/** 폴더 목록 응답. unclassifiedCount는 어느 폴더에도 속하지 않은 기록 수(미분류). */
+public record FolderListResponse(List<FolderSummaryResponse> folders, long unclassifiedCount) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderResponse.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderResponse.java
@@ -1,0 +1,4 @@
+package com.icc.qasker.quizhistory.dto.feresponse;
+
+/** 폴더 생성 응답. folderId는 Hashids 인코딩 문자열. */
+public record FolderResponse(String folderId, String name) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderSummaryResponse.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/FolderSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.icc.qasker.quizhistory.dto.feresponse;
+
+/** 폴더 목록 항목. count는 해당 폴더에 속한 기록 수. */
+public record FolderSummaryResponse(String folderId, String name, long count) {}

--- a/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/HistorySummaryResponse.java
+++ b/modules/quiz-history/api/src/main/java/com/icc/qasker/quizhistory/dto/feresponse/HistorySummaryResponse.java
@@ -12,4 +12,6 @@ public record HistorySummaryResponse(
     int totalCount,
     boolean completed,
     Integer score,
-    Instant takenAt) {}
+    Instant takenAt,
+    String folderId,
+    String folderName) {}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizFolderCommandController.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizFolderCommandController.java
@@ -1,0 +1,60 @@
+package com.icc.qasker.quizhistory.controller;
+
+import com.icc.qasker.global.annotation.RateLimit;
+import com.icc.qasker.global.annotation.UserId;
+import com.icc.qasker.global.ratelimit.RateLimitTier;
+import com.icc.qasker.quizhistory.QuizFolderCommandService;
+import com.icc.qasker.quizhistory.dto.ferequest.CreateFolderRequest;
+import com.icc.qasker.quizhistory.dto.ferequest.RenameFolderRequest;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 퀴즈 기록 폴더 커맨드 API (생성·이름변경·삭제). */
+@Tag(name = "QuizFolder", description = "퀴즈 기록 폴더 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/folders")
+public class QuizFolderCommandController {
+
+  private final QuizFolderCommandService quizFolderCommandService;
+
+  @Operation(summary = "폴더를 생성한다")
+  @RateLimit(RateLimitTier.WRITE)
+  @PostMapping
+  public ResponseEntity<FolderResponse> createFolder(
+      @UserId String userId, @RequestBody CreateFolderRequest request) {
+    FolderResponse response = quizFolderCommandService.createFolder(userId, request.name());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "폴더 이름을 변경한다")
+  @RateLimit(RateLimitTier.WRITE)
+  @PatchMapping("/{folderId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void renameFolder(
+      @UserId String userId,
+      @PathVariable String folderId,
+      @RequestBody RenameFolderRequest request) {
+    quizFolderCommandService.renameFolder(userId, folderId, request.name());
+  }
+
+  @Operation(summary = "폴더를 삭제한다 (소속 기록은 미분류로 이동)")
+  @RateLimit(RateLimitTier.WRITE)
+  @DeleteMapping("/{folderId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteFolder(@UserId String userId, @PathVariable String folderId) {
+    quizFolderCommandService.deleteFolder(userId, folderId);
+  }
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizFolderQueryController.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizFolderQueryController.java
@@ -1,0 +1,28 @@
+package com.icc.qasker.quizhistory.controller;
+
+import com.icc.qasker.global.annotation.UserId;
+import com.icc.qasker.quizhistory.QuizFolderQueryService;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 퀴즈 기록 폴더 조회 API (내 폴더 목록 + 폴더별/미분류 기록 수). */
+@Tag(name = "QuizFolder", description = "퀴즈 기록 폴더 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/folders")
+public class QuizFolderQueryController {
+
+  private final QuizFolderQueryService quizFolderQueryService;
+
+  @Operation(summary = "내 폴더 목록과 폴더별/미분류 기록 수를 조회한다")
+  @GetMapping
+  public ResponseEntity<FolderListResponse> getFolders(@UserId String userId) {
+    return ResponseEntity.ok(quizFolderQueryService.getFolders(userId));
+  }
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizHistoryCommandController.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizHistoryCommandController.java
@@ -4,6 +4,7 @@ import com.icc.qasker.global.annotation.RateLimit;
 import com.icc.qasker.global.annotation.UserId;
 import com.icc.qasker.global.ratelimit.RateLimitTier;
 import com.icc.qasker.quizhistory.QuizHistoryCommandService;
+import com.icc.qasker.quizhistory.dto.ferequest.AssignFolderRequest;
 import com.icc.qasker.quizhistory.dto.ferequest.ChangeHistoryTitleRequest;
 import com.icc.qasker.quizhistory.dto.ferequest.InitHistoryRequest;
 import com.icc.qasker.quizhistory.dto.ferequest.SaveHistoryRequest;
@@ -63,6 +64,17 @@ public class QuizHistoryCommandController {
       @PathVariable String historyId,
       @Valid @RequestBody ChangeHistoryTitleRequest request) {
     quizHistoryCommandService.updateHistoryTitle(userId, historyId, request.title());
+  }
+
+  @Operation(summary = "퀴즈 기록을 폴더에 배정하거나 미분류로 해제한다 (folderId=null이면 해제)")
+  @RateLimit(RateLimitTier.WRITE)
+  @PatchMapping("/{historyId}/folder")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void assignFolder(
+      @UserId String userId,
+      @PathVariable String historyId,
+      @RequestBody AssignFolderRequest request) {
+    quizHistoryCommandService.assignFolder(userId, historyId, request.folderId());
   }
 
   @Operation(summary = "특정 퀴즈 기록을 삭제한다")

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizHistoryQueryController.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/controller/QuizHistoryQueryController.java
@@ -2,6 +2,7 @@ package com.icc.qasker.quizhistory.controller;
 
 import com.icc.qasker.global.annotation.UserId;
 import com.icc.qasker.quizhistory.QuizHistoryQueryService;
+import com.icc.qasker.quizhistory.dto.ferequest.HistoryScope;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryCheckResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryDetailResponse;
@@ -36,13 +37,16 @@ public class QuizHistoryQueryController {
     return ResponseEntity.ok(quizHistoryQueryService.checkHistory(userId, problemSetId));
   }
 
-  @Operation(summary = "내 퀴즈 히스토리 목록을 페이지 단위로 조회한다")
+  @Operation(summary = "내 퀴즈 히스토리 목록을 페이지 단위로 조회한다 (전체/미분류/특정 폴더)")
   @GetMapping
   public ResponseEntity<HistoryPageResponse> getHistoryList(
       @UserId String userId,
+      @RequestParam(defaultValue = "ALL") HistoryScope scope,
+      @RequestParam(required = false) String folderId,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size) {
-    return ResponseEntity.ok(quizHistoryQueryService.getHistoryList(userId, page, size));
+    return ResponseEntity.ok(
+        quizHistoryQueryService.getHistoryList(userId, scope, folderId, page, size));
   }
 
   @Operation(summary = "퀴즈 히스토리 상세를 조회한다 (문제 + 답안 + 정답)")

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/entity/QuizFolder.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/entity/QuizFolder.java
@@ -1,0 +1,38 @@
+package com.icc.qasker.quizhistory.entity;
+
+import com.icc.qasker.global.entity.CreatedAt;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 사용자가 자신의 퀴즈 기록을 묶는 명명된 폴더. 소유자(userId)와 이름을 가진다. */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "quiz_folder")
+public class QuizFolder extends CreatedAt {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String userId;
+
+  @Column(nullable = false, length = 50)
+  private String name;
+
+  public void rename(String name) {
+    this.name = name;
+  }
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/entity/QuizHistory.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/entity/QuizHistory.java
@@ -43,6 +43,9 @@ public class QuizHistory extends CreatedAt {
   @Column(nullable = false)
   private Long problemSetId;
 
+  /** 소속 폴더 id. null이면 미분류(어느 폴더에도 속하지 않음). */
+  @Column private Long folderId;
+
   @Column(length = 100)
   private String title;
 
@@ -61,6 +64,11 @@ public class QuizHistory extends CreatedAt {
 
   public void updateTitle(String title) {
     this.title = title;
+  }
+
+  /** 폴더 배정/해제. folderId가 null이면 미분류로 되돌린다(단일 소속: 기존 소속을 덮어씀). */
+  public void assignFolder(Long folderId) {
+    this.folderId = folderId;
   }
 
   public void completeQuiz(List<AnswerSnapshot> answers, Integer score, String totalTime) {

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/mapper/QuizHistoryMapper.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/mapper/QuizHistoryMapper.java
@@ -26,13 +26,15 @@ public final class QuizHistoryMapper {
 
   private final HashUtil hashUtil;
 
-  /** QuizHistory + ProblemSetSummary → HistorySummaryResponse 변환 */
-  public HistorySummaryResponse toSummary(QuizHistory history, ProblemSetSummary problemSet) {
+  /** QuizHistory + ProblemSetSummary → HistorySummaryResponse 변환. folderName은 미분류면 null. */
+  public HistorySummaryResponse toSummary(
+      QuizHistory history, ProblemSetSummary problemSet, String folderName) {
     boolean completed =
         switch (history.getStatus()) {
           case COMPLETED -> true;
           case INCOMPLETE -> false;
         };
+    String folderId = history.getFolderId() == null ? null : hashUtil.encode(history.getFolderId());
     return new HistorySummaryResponse(
         hashUtil.encode(problemSet.id()),
         history.getTitle(),
@@ -42,7 +44,9 @@ public final class QuizHistoryMapper {
         problemSet.totalQuizCount(),
         completed,
         history.getScore(),
-        history.getCreatedAt());
+        history.getCreatedAt(),
+        folderId,
+        folderName);
   }
 
   /** ProblemDetail + 답안 스냅샷 → ProblemWithAnswer(객관식 상세) 변환. 정답 인덱스와 사용자 답을 비교해 정오답을 판정한다. */

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/FolderCount.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/FolderCount.java
@@ -1,0 +1,8 @@
+package com.icc.qasker.quizhistory.repository;
+
+/** 폴더별 기록 수 집계 프로젝션. */
+public interface FolderCount {
+  Long getFolderId();
+
+  long getCount();
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/QuizFolderRepository.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/QuizFolderRepository.java
@@ -1,0 +1,15 @@
+package com.icc.qasker.quizhistory.repository;
+
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizFolderRepository extends JpaRepository<QuizFolder, Long> {
+
+  long countByUserId(String userId);
+
+  Optional<QuizFolder> findByIdAndUserId(Long id, String userId);
+
+  List<QuizFolder> findAllByUserIdOrderByCreatedAtDesc(String userId);
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/QuizHistoryRepository.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/repository/QuizHistoryRepository.java
@@ -15,9 +15,29 @@ public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> 
 
   Page<QuizHistory> findAllByUserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
 
+  Page<QuizHistory> findAllByUserIdAndFolderIdOrderByCreatedAtDesc(
+      String userId, Long folderId, Pageable pageable);
+
+  Page<QuizHistory> findAllByUserIdAndFolderIdIsNullOrderByCreatedAtDesc(
+      String userId, Pageable pageable);
+
+  long countByUserIdAndFolderIdIsNull(String userId);
+
   Optional<QuizHistory> findByIdAndUserId(Long id, String userId);
 
   Optional<QuizHistory> findByUserIdAndProblemSetId(String userId, Long problemSetId);
+
+  /** 사용자의 폴더별 기록 수(미분류 제외). */
+  @Query(
+      "SELECT h.folderId AS folderId, COUNT(h) AS count FROM QuizHistory h"
+          + " WHERE h.userId = :userId AND h.folderId IS NOT NULL GROUP BY h.folderId")
+  List<FolderCount> countGroupedByFolder(String userId);
+
+  /** 폴더 삭제 시 소속 기록을 미분류로 되돌린다. */
+  @Modifying
+  @Query(
+      "UPDATE QuizHistory h SET h.folderId = NULL WHERE h.folderId = :folderId AND h.userId = :userId")
+  void clearFolderByFolderIdAndUserId(Long folderId, String userId);
 
   @Modifying
   @Query("DELETE FROM QuizHistory h WHERE h.id = :id AND h.userId = :userId")

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizFolderCommandServiceImpl.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizFolderCommandServiceImpl.java
@@ -1,0 +1,70 @@
+package com.icc.qasker.quizhistory.service;
+
+import com.icc.qasker.global.component.HashUtil;
+import com.icc.qasker.global.error.CustomException;
+import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.quizhistory.QuizFolderCommandService;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderResponse;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
+import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizFolderCommandServiceImpl implements QuizFolderCommandService {
+
+  private static final int MAX_FOLDERS = 100;
+  private static final int MAX_NAME_LENGTH = 50;
+
+  private final QuizFolderRepository quizFolderRepository;
+  private final QuizHistoryRepository quizHistoryRepository;
+  private final HashUtil hashUtil;
+
+  @Override
+  @Transactional
+  public FolderResponse createFolder(String userId, String name) {
+    String trimmed = validateName(name);
+    if (quizFolderRepository.countByUserId(userId) >= MAX_FOLDERS) {
+      throw new CustomException(ExceptionMessage.FOLDER_LIMIT_EXCEEDED);
+    }
+    QuizFolder folder = QuizFolder.builder().userId(userId).name(trimmed).build();
+    QuizFolder saved = quizFolderRepository.save(folder);
+    return new FolderResponse(hashUtil.encode(saved.getId()), saved.getName());
+  }
+
+  @Override
+  @Transactional
+  public void renameFolder(String userId, String folderId, String name) {
+    String trimmed = validateName(name);
+    QuizFolder folder = loadOwnedFolder(userId, folderId);
+    folder.rename(trimmed);
+  }
+
+  @Override
+  @Transactional
+  public void deleteFolder(String userId, String folderId) {
+    QuizFolder folder = loadOwnedFolder(userId, folderId);
+    quizHistoryRepository.clearFolderByFolderIdAndUserId(folder.getId(), userId);
+    quizFolderRepository.delete(folder);
+  }
+
+  private QuizFolder loadOwnedFolder(String userId, String folderId) {
+    return quizFolderRepository
+        .findByIdAndUserId(hashUtil.decode(folderId), userId)
+        .orElseThrow(() -> new CustomException(ExceptionMessage.FOLDER_NOT_FOUND));
+  }
+
+  private String validateName(String name) {
+    if (name == null) {
+      throw new CustomException(ExceptionMessage.FOLDER_NAME_INVALID);
+    }
+    String trimmed = name.trim();
+    if (trimmed.isEmpty() || trimmed.length() > MAX_NAME_LENGTH) {
+      throw new CustomException(ExceptionMessage.FOLDER_NAME_INVALID);
+    }
+    return trimmed;
+  }
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizFolderQueryServiceImpl.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizFolderQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package com.icc.qasker.quizhistory.service;
+
+import com.icc.qasker.global.component.HashUtil;
+import com.icc.qasker.quizhistory.QuizFolderQueryService;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderListResponse;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderSummaryResponse;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import com.icc.qasker.quizhistory.repository.FolderCount;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
+import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizFolderQueryServiceImpl implements QuizFolderQueryService {
+
+  private final QuizFolderRepository quizFolderRepository;
+  private final QuizHistoryRepository quizHistoryRepository;
+  private final HashUtil hashUtil;
+
+  @Override
+  public FolderListResponse getFolders(String userId) {
+    List<QuizFolder> folders = quizFolderRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+    Map<Long, Long> countMap =
+        quizHistoryRepository.countGroupedByFolder(userId).stream()
+            .collect(Collectors.toMap(FolderCount::getFolderId, FolderCount::getCount));
+
+    List<FolderSummaryResponse> summaries =
+        folders.stream()
+            .map(
+                f ->
+                    new FolderSummaryResponse(
+                        hashUtil.encode(f.getId()),
+                        f.getName(),
+                        countMap.getOrDefault(f.getId(), 0L)))
+            .toList();
+
+    long unclassifiedCount = quizHistoryRepository.countByUserIdAndFolderIdIsNull(userId);
+    return new FolderListResponse(summaries, unclassifiedCount);
+  }
+}

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImpl.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.icc.qasker.quizhistory.dto.ferequest.InitHistoryRequest;
 import com.icc.qasker.quizhistory.dto.ferequest.SaveHistoryRequest;
 import com.icc.qasker.quizhistory.entity.AnswerSnapshot;
 import com.icc.qasker.quizhistory.entity.QuizHistory;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
 import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizHistoryCommandServiceImpl implements QuizHistoryCommandService {
 
   private final QuizHistoryRepository quizHistoryRepository;
+  private final QuizFolderRepository quizFolderRepository;
   private final HashUtil hashUtil;
 
   @Override
@@ -76,6 +78,25 @@ public class QuizHistoryCommandServiceImpl implements QuizHistoryCommandService 
             .findByIdAndUserId(decodedHistoryId, userId)
             .orElseThrow(() -> new CustomException(ExceptionMessage.QUIZ_HISTORY_NOT_FOUND));
     history.updateTitle(title);
+  }
+
+  @Override
+  @Transactional
+  public void assignFolder(String userId, String historyId, String folderId) {
+    QuizHistory history =
+        quizHistoryRepository
+            .findByIdAndUserId(hashUtil.decode(historyId), userId)
+            .orElseThrow(() -> new CustomException(ExceptionMessage.QUIZ_HISTORY_NOT_FOUND));
+
+    Long targetFolderId = null;
+    if (folderId != null) {
+      targetFolderId =
+          quizFolderRepository
+              .findByIdAndUserId(hashUtil.decode(folderId), userId)
+              .orElseThrow(() -> new CustomException(ExceptionMessage.FOLDER_NOT_FOUND))
+              .getId();
+    }
+    history.assignFolder(targetFolderId);
   }
 
   @Override

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryQueryServiceImpl.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.icc.qasker.global.component.HashUtil;
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
 import com.icc.qasker.quizhistory.QuizHistoryQueryService;
+import com.icc.qasker.quizhistory.dto.ferequest.HistoryScope;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse.EssayProblemWithGrade;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryCheckResponse;
@@ -13,9 +14,11 @@ import com.icc.qasker.quizhistory.dto.feresponse.HistorySummaryResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.ProblemWithAnswer;
 import com.icc.qasker.quizhistory.entity.AnswerSnapshotView;
 import com.icc.qasker.quizhistory.entity.EssayGradeLog;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
 import com.icc.qasker.quizhistory.entity.QuizHistory;
 import com.icc.qasker.quizhistory.mapper.QuizHistoryMapper;
 import com.icc.qasker.quizhistory.repository.EssayGradeLogRepository;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
 import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
 import com.icc.qasker.quizset.ProblemSetReadService;
 import com.icc.qasker.quizset.dto.readonly.ProblemDetail;
@@ -28,6 +31,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,18 +41,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizHistoryQueryServiceImpl implements QuizHistoryQueryService {
 
   private final QuizHistoryRepository quizHistoryRepository;
+  private final QuizFolderRepository quizFolderRepository;
   private final EssayGradeLogRepository essayGradeLogRepository;
   private final ProblemSetReadService problemSetReadService;
   private final HashUtil hashUtil;
   private final QuizHistoryMapper quizHistoryMapper;
 
   @Override
-  public HistoryPageResponse getHistoryList(String userId, int page, int size) {
+  public HistoryPageResponse getHistoryList(
+      String userId, HistoryScope scope, String folderId, int page, int size) {
 
-    // 페이지 단위로 히스토리 조회
+    // 페이지 단위로 히스토리 조회 (탐색 범위 3종: 전체/미분류/특정 폴더)
     Pageable pageable = Pageable.ofSize(size).withPage(page);
-    Page<QuizHistory> historyPage =
-        quizHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable);
+    Page<QuizHistory> historyPage = loadHistoryPage(userId, scope, folderId, pageable);
 
     List<QuizHistory> histories = historyPage.getContent();
     if (histories.isEmpty()) {
@@ -67,14 +72,33 @@ public class QuizHistoryQueryServiceImpl implements QuizHistoryQueryService {
         problemSetReadService.findProblemSetsByIds(problemSetIds).stream()
             .collect(Collectors.toMap(ProblemSetSummary::id, Function.identity()));
 
+    // 소속 폴더명 IN 쿼리 1번으로 일괄 조회 후 Map으로 변환 (미분류 기록은 조회 대상 아님)
+    List<Long> folderIds =
+        histories.stream()
+            .map(QuizHistory::getFolderId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    Map<Long, String> folderNameMap =
+        folderIds.isEmpty()
+            ? Map.of()
+            : quizFolderRepository.findAllById(folderIds).stream()
+                .collect(Collectors.toMap(QuizFolder::getId, QuizFolder::getName));
+
     List<HistorySummaryResponse> content =
         histories.stream()
             .map(
-                history ->
-                    problemSetMap.get(history.getProblemSetId()) == null
-                        ? null
-                        : quizHistoryMapper.toSummary(
-                            history, problemSetMap.get(history.getProblemSetId())))
+                history -> {
+                  ProblemSetSummary problemSet = problemSetMap.get(history.getProblemSetId());
+                  if (problemSet == null) {
+                    return null;
+                  }
+                  String folderName =
+                      history.getFolderId() == null
+                          ? null
+                          : folderNameMap.get(history.getFolderId());
+                  return quizHistoryMapper.toSummary(history, problemSet, folderName);
+                })
             .filter(Objects::nonNull)
             .toList();
 
@@ -84,6 +108,23 @@ public class QuizHistoryQueryServiceImpl implements QuizHistoryQueryService {
         historyPage.getTotalPages(),
         historyPage.getNumber(),
         historyPage.getSize());
+  }
+
+  private Page<QuizHistory> loadHistoryPage(
+      String userId, HistoryScope scope, String folderId, Pageable pageable) {
+    return switch (scope) {
+      case ALL -> quizHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable);
+      case UNCLASSIFIED ->
+          quizHistoryRepository.findAllByUserIdAndFolderIdIsNullOrderByCreatedAtDesc(
+              userId, pageable);
+      case FOLDER -> {
+        if (folderId == null || folderId.isBlank()) {
+          throw new CustomException(HttpStatus.BAD_REQUEST, "folderId가 필요합니다.");
+        }
+        yield quizHistoryRepository.findAllByUserIdAndFolderIdOrderByCreatedAtDesc(
+            userId, hashUtil.decode(folderId), pageable);
+      }
+    };
   }
 
   @Override

--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/mock/MockQuizHistoryCommandService.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/mock/MockQuizHistoryCommandService.java
@@ -44,6 +44,11 @@ public class MockQuizHistoryCommandService implements QuizHistoryCommandService 
   }
 
   @Override
+  public void assignFolder(String userId, String historyId, String folderId) {
+    selfCleanWrite(userId, "mock");
+  }
+
+  @Override
   public void deleteAllHistory(String userId) {
     selfCleanWrite(userId, "mock");
   }

--- a/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizFolderCommandServiceImplTest.java
+++ b/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizFolderCommandServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.icc.qasker.quizhistory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.icc.qasker.global.component.HashUtil;
+import com.icc.qasker.global.error.CustomException;
+import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderResponse;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
+import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QuizFolderCommandServiceImplTest {
+
+  @Mock private QuizFolderRepository quizFolderRepository;
+  @Mock private QuizHistoryRepository quizHistoryRepository;
+  @Mock private HashUtil hashUtil;
+
+  @InjectMocks private QuizFolderCommandServiceImpl service;
+
+  @Test
+  @DisplayName("createFolder: 상한 미만이면 이름을 trim해 저장하고 인코딩 id를 반환")
+  void createFolder_success() {
+    when(quizFolderRepository.countByUserId("u1")).thenReturn(3L);
+    when(quizFolderRepository.save(any()))
+        .thenReturn(QuizFolder.builder().id(1L).userId("u1").name("수학").build());
+    when(hashUtil.encode(anyLong())).thenReturn("ENC");
+
+    FolderResponse response = service.createFolder("u1", "  수학  ");
+
+    assertThat(response.folderId()).isEqualTo("ENC");
+    assertThat(response.name()).isEqualTo("수학");
+  }
+
+  @Test
+  @DisplayName("createFolder: 폴더 100개면 FOLDER_LIMIT_EXCEEDED, 저장하지 않음")
+  void createFolder_atLimit_throws() {
+    when(quizFolderRepository.countByUserId("u1")).thenReturn(100L);
+
+    assertThatThrownBy(() -> service.createFolder("u1", "새폴더"))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.FOLDER_LIMIT_EXCEEDED.getMessage());
+    verify(quizFolderRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("createFolder: 빈/공백/50자 초과 이름은 FOLDER_NAME_INVALID")
+  void createFolder_invalidName_throws() {
+    assertThatThrownBy(() -> service.createFolder("u1", "   "))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.FOLDER_NAME_INVALID.getMessage());
+
+    String tooLong = "a".repeat(51);
+    assertThatThrownBy(() -> service.createFolder("u1", tooLong))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.FOLDER_NAME_INVALID.getMessage());
+
+    verify(quizFolderRepository, never()).countByUserId(any());
+    verify(quizFolderRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("createFolder: 정확히 50자는 허용")
+  void createFolder_exactly50_ok() {
+    String name = "a".repeat(50);
+    when(quizFolderRepository.countByUserId("u1")).thenReturn(0L);
+    when(quizFolderRepository.save(any()))
+        .thenReturn(QuizFolder.builder().id(1L).userId("u1").name(name).build());
+    lenient().when(hashUtil.encode(anyLong())).thenReturn("ENC");
+
+    FolderResponse response = service.createFolder("u1", name);
+
+    assertThat(response.name()).isEqualTo(name);
+  }
+
+  @Test
+  @DisplayName("renameFolder: 소유 폴더면 rename 호출")
+  void renameFolder_success() {
+    QuizFolder folder = QuizFolder.builder().id(7L).userId("u1").name("old").build();
+    when(hashUtil.decode("f7")).thenReturn(7L);
+    when(quizFolderRepository.findByIdAndUserId(7L, "u1")).thenReturn(Optional.of(folder));
+
+    service.renameFolder("u1", "f7", "  new  ");
+
+    assertThat(folder.getName()).isEqualTo("new");
+  }
+
+  @Test
+  @DisplayName("renameFolder: 타인/미존재 폴더는 FOLDER_NOT_FOUND")
+  void renameFolder_notOwned_throws() {
+    when(hashUtil.decode("f7")).thenReturn(7L);
+    when(quizFolderRepository.findByIdAndUserId(7L, "u1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.renameFolder("u1", "f7", "new"))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.FOLDER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("deleteFolder: 소속 기록을 미분류로 이동 후 폴더 삭제")
+  void deleteFolder_movesToUnclassifiedThenDeletes() {
+    QuizFolder folder = QuizFolder.builder().id(9L).userId("u1").name("x").build();
+    when(hashUtil.decode("f9")).thenReturn(9L);
+    when(quizFolderRepository.findByIdAndUserId(9L, "u1")).thenReturn(Optional.of(folder));
+
+    service.deleteFolder("u1", "f9");
+
+    verify(quizHistoryRepository).clearFolderByFolderIdAndUserId(9L, "u1");
+    verify(quizFolderRepository).delete(folder);
+  }
+
+  @Test
+  @DisplayName("deleteFolder: 타인/미존재 폴더는 FOLDER_NOT_FOUND, 이동/삭제 없음")
+  void deleteFolder_notOwned_throws() {
+    when(hashUtil.decode("f9")).thenReturn(9L);
+    when(quizFolderRepository.findByIdAndUserId(9L, "u1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.deleteFolder("u1", "f9")).isInstanceOf(CustomException.class);
+    verify(quizHistoryRepository, never()).clearFolderByFolderIdAndUserId(anyLong(), any());
+    verify(quizFolderRepository, never()).delete(any());
+  }
+}

--- a/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizFolderQueryServiceImplTest.java
+++ b/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizFolderQueryServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.icc.qasker.quizhistory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.icc.qasker.global.component.HashUtil;
+import com.icc.qasker.quizhistory.dto.feresponse.FolderListResponse;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import com.icc.qasker.quizhistory.repository.FolderCount;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
+import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QuizFolderQueryServiceImplTest {
+
+  @Mock private QuizFolderRepository quizFolderRepository;
+  @Mock private QuizHistoryRepository quizHistoryRepository;
+  @Mock private HashUtil hashUtil;
+
+  @InjectMocks private QuizFolderQueryServiceImpl service;
+
+  private record Count(Long folderId, long count) implements FolderCount {
+    @Override
+    public Long getFolderId() {
+      return folderId;
+    }
+
+    @Override
+    public long getCount() {
+      return count;
+    }
+  }
+
+  @Test
+  @DisplayName("getFolders: 폴더별 count 매핑(집계 없는 폴더는 0) + unclassifiedCount 반환")
+  void getFolders_mapsCountsAndUnclassified() {
+    when(quizFolderRepository.findAllByUserIdOrderByCreatedAtDesc("u1"))
+        .thenReturn(
+            List.of(
+                QuizFolder.builder().id(1L).userId("u1").name("수학").build(),
+                QuizFolder.builder().id(2L).userId("u1").name("영어").build()));
+    when(quizHistoryRepository.countGroupedByFolder("u1"))
+        .thenReturn(List.of(new Count(1L, 12L))); // 2번 폴더는 집계 없음 → 0
+    when(quizHistoryRepository.countByUserIdAndFolderIdIsNull("u1")).thenReturn(5L);
+    lenient().when(hashUtil.encode(anyLong())).thenReturn("ENC");
+
+    FolderListResponse response = service.getFolders("u1");
+
+    assertThat(response.folders()).hasSize(2);
+    assertThat(response.folders().get(0).count()).isEqualTo(12L);
+    assertThat(response.folders().get(1).count()).isEqualTo(0L);
+    assertThat(response.unclassifiedCount()).isEqualTo(5L);
+  }
+}

--- a/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImplTest.java
+++ b/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImplTest.java
@@ -1,0 +1,86 @@
+package com.icc.qasker.quizhistory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.icc.qasker.global.component.HashUtil;
+import com.icc.qasker.global.error.CustomException;
+import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.quizhistory.entity.QuizFolder;
+import com.icc.qasker.quizhistory.entity.QuizHistory;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
+import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QuizHistoryCommandServiceImplTest {
+
+  @Mock private QuizHistoryRepository quizHistoryRepository;
+  @Mock private QuizFolderRepository quizFolderRepository;
+  @Mock private HashUtil hashUtil;
+
+  @InjectMocks private QuizHistoryCommandServiceImpl service;
+
+  @Test
+  @DisplayName("assignFolder: 소유 기록을 소유 폴더에 배정 (단일 소속 덮어쓰기)")
+  void assignFolder_assigns() {
+    QuizHistory history =
+        QuizHistory.builder().id(1L).userId("u1").problemSetId(10L).folderId(2L).build();
+    when(hashUtil.decode("h1")).thenReturn(1L);
+    when(quizHistoryRepository.findByIdAndUserId(1L, "u1")).thenReturn(Optional.of(history));
+    when(hashUtil.decode("f5")).thenReturn(5L);
+    when(quizFolderRepository.findByIdAndUserId(5L, "u1"))
+        .thenReturn(Optional.of(QuizFolder.builder().id(5L).userId("u1").name("수학").build()));
+
+    service.assignFolder("u1", "h1", "f5");
+
+    assertThat(history.getFolderId()).isEqualTo(5L);
+  }
+
+  @Test
+  @DisplayName("assignFolder: folderId=null이면 미분류로 해제")
+  void assignFolder_null_clears() {
+    QuizHistory history =
+        QuizHistory.builder().id(1L).userId("u1").problemSetId(10L).folderId(2L).build();
+    when(hashUtil.decode("h1")).thenReturn(1L);
+    when(quizHistoryRepository.findByIdAndUserId(1L, "u1")).thenReturn(Optional.of(history));
+
+    service.assignFolder("u1", "h1", null);
+
+    assertThat(history.getFolderId()).isNull();
+  }
+
+  @Test
+  @DisplayName("assignFolder: 타인/미존재 기록은 QUIZ_HISTORY_NOT_FOUND")
+  void assignFolder_historyNotFound() {
+    when(hashUtil.decode("h1")).thenReturn(1L);
+    when(quizHistoryRepository.findByIdAndUserId(1L, "u1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.assignFolder("u1", "h1", "f5"))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.QUIZ_HISTORY_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("assignFolder: 타인/미존재 폴더는 FOLDER_NOT_FOUND")
+  void assignFolder_folderNotFound() {
+    QuizHistory history = QuizHistory.builder().id(1L).userId("u1").problemSetId(10L).build();
+    when(hashUtil.decode("h1")).thenReturn(1L);
+    when(quizHistoryRepository.findByIdAndUserId(1L, "u1")).thenReturn(Optional.of(history));
+    when(hashUtil.decode("f5")).thenReturn(5L);
+    when(quizFolderRepository.findByIdAndUserId(5L, "u1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.assignFolder("u1", "h1", "f5"))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getMessage())
+        .isEqualTo(ExceptionMessage.FOLDER_NOT_FOUND.getMessage());
+  }
+}

--- a/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryQueryServiceImplTest.java
+++ b/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryQueryServiceImplTest.java
@@ -11,6 +11,7 @@ import com.icc.qasker.ai.dto.EssayGradingResult;
 import com.icc.qasker.global.component.HashUtil;
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.quizhistory.dto.ferequest.HistoryScope;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse;
 import com.icc.qasker.quizhistory.dto.feresponse.EssayHistoryDetailResponse.EssayProblemWithGrade;
 import com.icc.qasker.quizhistory.dto.feresponse.HistoryDetailResponse;
@@ -21,6 +22,7 @@ import com.icc.qasker.quizhistory.entity.EssayGradeLog;
 import com.icc.qasker.quizhistory.entity.QuizHistory;
 import com.icc.qasker.quizhistory.mapper.QuizHistoryMapper;
 import com.icc.qasker.quizhistory.repository.EssayGradeLogRepository;
+import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
 import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
 import com.icc.qasker.quizset.ProblemSetReadService;
 import com.icc.qasker.quizset.dto.ferequest.enums.QuizType;
@@ -48,6 +50,7 @@ import org.springframework.data.domain.Pageable;
 class QuizHistoryQueryServiceImplTest {
 
   @Mock private QuizHistoryRepository quizHistoryRepository;
+  @Mock private QuizFolderRepository quizFolderRepository;
   @Mock private EssayGradeLogRepository essayGradeLogRepository;
   @Mock private ProblemSetReadService problemSetReadService;
   @Mock private HashUtil hashUtil;
@@ -65,6 +68,7 @@ class QuizHistoryQueryServiceImplTest {
     service =
         new QuizHistoryQueryServiceImpl(
             quizHistoryRepository,
+            quizFolderRepository,
             essayGradeLogRepository,
             problemSetReadService,
             hashUtil,
@@ -243,10 +247,73 @@ class QuizHistoryQueryServiceImplTest {
     when(problemSetReadService.findProblemSetsByIds(List.of(100L, 200L)))
         .thenReturn(List.of(summary(100L, QuizType.MULTIPLE, 3)));
 
-    HistoryPageResponse response = service.getHistoryList(userId, 0, 10);
+    HistoryPageResponse response = service.getHistoryList(userId, HistoryScope.ALL, null, 0, 10);
 
     assertThat(response.content()).hasSize(1);
     assertThat(response.content().get(0).title()).isEqualTo("kept");
+  }
+
+  @Test
+  @DisplayName("getHistoryList FOLDER: 특정 폴더 쿼리로 조회하고 folderId/folderName을 매핑한다")
+  void getHistoryList_folderScope_mapsFolderName() {
+    String userId = "user1";
+    QuizHistory h =
+        QuizHistory.builder()
+            .id(1L)
+            .userId(userId)
+            .problemSetId(100L)
+            .title("in-folder")
+            .folderId(5L)
+            .build();
+    Pageable pageable = Pageable.ofSize(10).withPage(0);
+    Page<QuizHistory> page = new PageImpl<>(List.of(h), pageable, 1);
+    when(hashUtil.decode("f5")).thenReturn(5L);
+    when(quizHistoryRepository.findAllByUserIdAndFolderIdOrderByCreatedAtDesc(
+            eq(userId), eq(5L), eq(pageable)))
+        .thenReturn(page);
+    when(problemSetReadService.findProblemSetsByIds(List.of(100L)))
+        .thenReturn(List.of(summary(100L, QuizType.MULTIPLE, 3)));
+    when(quizFolderRepository.findAllById(List.of(5L)))
+        .thenReturn(
+            List.of(
+                com.icc.qasker.quizhistory.entity.QuizFolder.builder().id(5L).name("수학").build()));
+
+    HistoryPageResponse response = service.getHistoryList(userId, HistoryScope.FOLDER, "f5", 0, 10);
+
+    assertThat(response.content()).hasSize(1);
+    assertThat(response.content().get(0).folderId()).isEqualTo("ENC");
+    assertThat(response.content().get(0).folderName()).isEqualTo("수학");
+  }
+
+  @Test
+  @DisplayName("getHistoryList UNCLASSIFIED: 미분류(folderId IS NULL) 쿼리로 조회한다")
+  void getHistoryList_unclassifiedScope_usesNullFolderQuery() {
+    String userId = "user1";
+    QuizHistory h =
+        QuizHistory.builder().id(1L).userId(userId).problemSetId(100L).title("none").build();
+    Pageable pageable = Pageable.ofSize(10).withPage(0);
+    Page<QuizHistory> page = new PageImpl<>(List.of(h), pageable, 1);
+    when(quizHistoryRepository.findAllByUserIdAndFolderIdIsNullOrderByCreatedAtDesc(
+            eq(userId), eq(pageable)))
+        .thenReturn(page);
+    when(problemSetReadService.findProblemSetsByIds(List.of(100L)))
+        .thenReturn(List.of(summary(100L, QuizType.MULTIPLE, 3)));
+
+    HistoryPageResponse response =
+        service.getHistoryList(userId, HistoryScope.UNCLASSIFIED, null, 0, 10);
+
+    assertThat(response.content()).hasSize(1);
+    assertThat(response.content().get(0).folderId()).isNull();
+    assertThat(response.content().get(0).folderName()).isNull();
+  }
+
+  @Test
+  @DisplayName("getHistoryList FOLDER: folderId 누락 시 400(BAD_REQUEST)")
+  void getHistoryList_folderScope_missingFolderId_throwsBadRequest() {
+    assertThatThrownBy(() -> service.getHistoryList("user1", HistoryScope.FOLDER, null, 0, 10))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getHttpStatus())
+        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
   }
 
   @Test


### PR DESCRIPTION
폴더 CRUD + 기록 단일 소속 배정/해제 + 목록 탐색 3종(전체/미분류/특정 폴더).

- quiz_folder 엔티티/테이블(V16) + quiz_history.folder_id nullable 컬럼으로 단일 소속 표현
- POST/GET/PATCH/DELETE /folders, PATCH /history/{id}/folder, GET /history?scope=...&folderId
- HistorySummaryResponse에 folderId·folderName 추가, GET /folders에 count·unclassifiedCount
- 이름 검증(≤50)·개수 상한(100)·소유권·삭제 시 미분류 이동은 서비스 계층 CustomException
- 오류 코드 안정화: CustomErrorResponse에 nullable code 필드(하위호환) + FOLDER_* 예외 3종 (FOLDER_LIMIT_EXCEEDED=409, 구분은 code 필드로)
- /folders 엔드포인트 인증 필수화: SecurityConfig에 authenticated() 매처 추가
- quiz-history-impl 기능 테스트 동반(폴더 CRUD·단일소속·필터3종·소유권·상한·이름검증·미분류이동)

<!-- prettier-ignore-start -->

## 📢 설명

### 변경 1: [제목]

[변경에 대한 설명]

#### 의사 선택과정 (trade-off)

> trade-off가 있는 경우에만 작성

**얻은 것**
-

**잃은 것**
-

### 코드 설명: 인라인 코멘트 확인

## ✅ 체크 리스트

### 재현 확인

<!-- 리뷰어가 직접 따라하며 변경사항을 확인할 수 있는 단계 -->

- [ ] (PR 작성 시 채워주세요)

### 기본

- [ ] 의사 선택 과정이 적절한지 확인
- [ ] 코드 리뷰

---
<!-- prettier-ignore-end -->
