### PR TITLE
📈 feat: 인앱 쿼리 계측 인프라 확장 (요청 리소스·JFR 메서드 타이밍)

### DIFF
--- a/app/src/main/java/com/icc/qasker/loadtest/JfrMethodTimingExporter.java
+++ b/app/src/main/java/com/icc/qasker/loadtest/JfrMethodTimingExporter.java
@@ -1,0 +1,143 @@
+package com.icc.qasker.loadtest;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import jdk.jfr.consumer.RecordingStream;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * JEP 520 {@code jdk.MethodTiming} 이벤트를 실행 중에 구독해(JFR 이벤트 스트리밍) Micrometer 게이지로 노출한다 — run.sh가 .jfr
+ * 파일을 사후 파싱하던 것을 Prometheus 스크레이프 경로에 합류시켜, 대시보드(qasker-enh-rw)가 mode=off|on 태그로 메서드 수준 계측을
+ * 지연·CPU·할당 패널과 나란히 보여줄 수 있게 한다.
+ *
+ * <ul>
+ *   <li>{@code jfr_method_invocations{method=...}} — 앱 기동 이후 누적 호출 수
+ *   <li>{@code jfr_method_time_total_seconds{method=...}} — 누적 실행 시간(= 호출 수 × 평균, 경과 시간)
+ * </ul>
+ *
+ * <p>이벤트는 주기 발행되는 누적 스냅샷이라 게이지로 두고, 대시보드는 다른 패널과 동일하게 {@code last_over_time(...[$__range])}로 런 종료
+ * 시점 값을 집는다. 오버로드가 여러 개인 메서드(areEquals)는 시그니처별 이벤트를 내부 맵에 따로 쌓고 같은 {@code Class.method} 라벨로 합산한다.
+ *
+ * <p>계측 대상 필터는 run.sh의 MT_FILTER 6종과 동기 유지할 것. -XX:StartFlightRecording과 동시 사용 가능 (JFR 다중 레코딩 허용 —
+ * 계측은 한 번만 심어진다).
+ */
+@Component
+@Profile("local")
+public class JfrMethodTimingExporter {
+
+  /**
+   * run.sh MT_FILTER와 동일: 순수 CPU 5종(더티체크 4 + 조립 창 readRow) + 혼합 창 1종(executeQuery — 대기 포함 wall이라
+   * CPU 주장 금지, 지연 분해용).
+   */
+  private static final String FILTER =
+      "org.hibernate.event.internal.DefaultFlushEntityEventListener::getDirtyPropertiesFromSelfDirtinessTracker;"
+          + "org.hibernate.persister.entity.AbstractEntityPersister::resolveDirtyAttributeIndexes;"
+          + "org.hibernate.bytecode.enhance.internal.bytebuddy.InlineDirtyCheckerEqualsHelper::areEquals;"
+          + "org.hibernate.event.internal.DefaultFlushEntityEventListener::performDirtyCheck;"
+          + "org.hibernate.sql.results.internal.StandardRowReader::readRow;"
+          + "org.hibernate.sql.results.jdbc.internal.DeferredResultSetAccess::executeQuery";
+
+  private record Stats(long invocations, double totalSeconds) {}
+
+  private final MeterRegistry registry;
+
+  /** 시그니처 전체(오버로드 구분) → 최신 누적 스냅샷. */
+  private final Map<String, Stats> bySignature = new ConcurrentHashMap<>();
+
+  /** 게이지를 등록한 짧은 라벨(Class.method) 집합 — 중복 등록 방지. */
+  private final Map<String, Boolean> registered = new ConcurrentHashMap<>();
+
+  private RecordingStream stream;
+
+  public JfrMethodTimingExporter(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * FILTER 5종의 짧은 라벨 — 기동 시 0으로 선등록해 시리즈가 앱 시작부터 존재하게 한다. 지연 등록이면 첫 이벤트 값(예: 장부 읽기 100)으로 시리즈가 태어나
+   * increase()가 도약을 놓치고, pooled(범위 평균) 패널에서 "1회차 요청에 활동이 몰린" 지표가 0으로 보인다.
+   */
+  private static final String[] KNOWN_LABELS = {
+    "DefaultFlushEntityEventListener.getDirtyPropertiesFromSelfDirtinessTracker",
+    "AbstractEntityPersister.resolveDirtyAttributeIndexes",
+    "InlineDirtyCheckerEqualsHelper.areEquals",
+    "DefaultFlushEntityEventListener.performDirtyCheck",
+    "StandardRowReader.readRow",
+    "DeferredResultSetAccess.executeQuery",
+  };
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void start() {
+    for (String label : KNOWN_LABELS) {
+      registerGauges(label);
+    }
+    stream = new RecordingStream();
+    stream.enable("jdk.MethodTiming").with("filter", FILTER).withPeriod(Duration.ofSeconds(5));
+    stream.onEvent(
+        "jdk.MethodTiming",
+        event -> {
+          var method = event.getValue("method");
+          if (!(method instanceof jdk.jfr.consumer.RecordedMethod recorded)) {
+            return;
+          }
+          String fqcn = recorded.getType().getName();
+          String shortLabel = fqcn.substring(fqcn.lastIndexOf('.') + 1) + "." + recorded.getName();
+          String signature = fqcn + "." + recorded.getName() + recorded.getDescriptor();
+
+          long invocations = event.getLong("invocations");
+          // average는 호출이 없으면 결측 — 그 경우 시간 0으로 둔다
+          double totalSeconds = 0;
+          if (invocations > 0) {
+            Duration avg = event.getDuration("average");
+            totalSeconds = invocations * avg.toNanos() / 1e9;
+          }
+          bySignature.put(signature, new Stats(invocations, totalSeconds));
+          registerGauges(shortLabel); // MT_EXTRA_FILTER로 추가된 메서드는 여기서 지연 등록
+        });
+    stream.startAsync();
+  }
+
+  private void registerGauges(String label) {
+    registered.computeIfAbsent(
+        label,
+        l -> {
+          Gauge.builder("jfr.method.invocations", () -> sum(l, Stats::invocations))
+              .tag("method", l)
+              .description("JEP 520 메서드 계측 — 앱 기동 이후 누적 호출 수")
+              .register(registry);
+          Gauge.builder("jfr.method.time.total", () -> sum(l, Stats::totalSeconds))
+              .tag("method", l)
+              .baseUnit("seconds")
+              .description("JEP 520 메서드 계측 — 누적 실행 시간(경과 시간)")
+              .register(registry);
+          return Boolean.TRUE;
+        });
+  }
+
+  /** 같은 Class.method 라벨에 속한 오버로드들의 값 합산. */
+  private double sum(String shortLabel, java.util.function.ToDoubleFunction<Stats> field) {
+    double total = 0;
+    for (Map.Entry<String, Stats> entry : bySignature.entrySet()) {
+      String signature = entry.getKey();
+      String beforeDescriptor = signature.substring(0, signature.indexOf('('));
+      if (beforeDescriptor.endsWith(shortLabel)) {
+        total += field.applyAsDouble(entry.getValue());
+      }
+    }
+    return total;
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (stream != null) {
+      stream.close();
+    }
+  }
+}

--- a/app/src/main/java/com/icc/qasker/loadtest/LocalSchedulerController.java
+++ b/app/src/main/java/com/icc/qasker/loadtest/LocalSchedulerController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 부하 테스트용 스케줄러 드라이버. 타이머(@Profile("!loadtest"))가 꺼진 loadtest에서 스케줄러 로직을 온디맨드로 1회 태운다. 그
+ * 부하 테스트용 스케줄러 드라이버. 타이머(@Profile("!local"))가 꺼진 local에서 스케줄러 로직을 온디맨드로 1회 태운다. 그
  * SELECT(findByGenerationStatusInAndCreatedAtBefore 스캔)가 계측 파이프라인에 잡혀, 비-controller 백그라운드 쿼리도 실
- * uri로 트레이스된다. @Profile("loadtest").
+ * uri로 트레이스된다. @Profile("local").
  */
 @RestController
-@Profile("loadtest")
+@Profile("local")
 @RequiredArgsConstructor
 @RequestMapping("/local/scheduler")
 public class LocalSchedulerController {

--- a/app/src/main/java/com/icc/qasker/loadtest/RequestResourceMetricsConfig.java
+++ b/app/src/main/java/com/icc/qasker/loadtest/RequestResourceMetricsConfig.java
@@ -11,7 +11,7 @@ import org.springframework.core.Ordered;
  * (Boot4CompatConfig와 같은 부류의 보완) FilterRegistrationBean으로 직접 서블릿 체인에 건다.
  */
 @Configuration
-@Profile("loadtest")
+@Profile("local")
 public class RequestResourceMetricsConfig {
 
   @Bean

--- a/app/src/main/java/com/icc/qasker/loadtest/RequestResourceMetricsFilter.java
+++ b/app/src/main/java/com/icc/qasker/loadtest/RequestResourceMetricsFilter.java
@@ -26,16 +26,25 @@ import org.springframework.web.servlet.HandlerMapping;
  * 가상 스레드 전환 시 이 지표는 무효가 된다.
  */
 @Component
-@Profile("loadtest")
+@Profile("local")
 public class RequestResourceMetricsFilter extends OncePerRequestFilter {
 
   private static final com.sun.management.ThreadMXBean THREADS =
       (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
 
+  /** 측정 엔드포인트 — 아래 선등록의 대상. */
+  private static final String MEASURED_URI = "/admin/problem-sets/explanation-review";
+
   private final MeterRegistry registry;
 
   public RequestResourceMetricsFilter(MeterRegistry registry) {
     this.registry = registry;
+    // 측정 uri의 카운터 3종을 앱 시작 시 0으로 선등록 — 시리즈가 부하 시작 전부터 존재해야
+    // 대시보드의 increase() 계산이 "첫 스크레이프 이전 증가분(머리)"을 잃지 않는다.
+    // (JfrMethodTimingExporter의 게이지 선등록과 같은 이유 — 분자·분모의 출생 시점을 맞춘다.)
+    registry.counter("request.count", "uri", MEASURED_URI);
+    registry.counter("request.thread.cpu.seconds", "uri", MEASURED_URI);
+    registry.counter("request.thread.allocated.bytes", "uri", MEASURED_URI);
   }
 
   @Override
@@ -48,6 +57,7 @@ public class RequestResourceMetricsFilter extends OncePerRequestFilter {
       filterChain.doFilter(request, response);
     } finally {
       String uri = templatedUri(request);
+      registry.counter("request.count", "uri", uri).increment();
       if (cpu0 >= 0) {
         long cpuDelta = THREADS.getCurrentThreadCpuTime() - cpu0;
         if (cpuDelta > 0) {

--- a/modules/global/src/main/java/com/icc/qasker/global/query/CountingInspector.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/query/CountingInspector.java
@@ -1,10 +1,17 @@
 package com.icc.qasker.global.query;
 
+import java.util.Objects;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.slf4j.MDC;
 
-/** Hibernate가 매 SQL 실행 직전 호출 — 요청당 쿼리수 카운트 + reqId·uri·repoMethod 주석 태깅. */
+/** Hibernate가 매 SQL 실행 직전 호출 — 요청당 쿼리수 카운트 + reqId·uri·repoMethod·mode 주석 태깅. */
 public class CountingInspector implements StatementInspector {
+
+  private final String modeTag;
+
+  public CountingInspector(String mode) {
+    this.modeTag = mode == null || mode.isBlank() ? "" : " mode=%-3s".formatted(mode);
+  }
 
   @Override
   public String inspect(String sql) {
@@ -14,14 +21,9 @@ public class CountingInspector implements StatementInspector {
       // 요청 컨텍스트 밖(스케줄러 등) — 태깅 생략
       return sql;
     }
-    String repoMethod = RepoMethodContext.resolve();
-    return "/* reqId="
-        + reqId
-        + " uri="
-        + MDC.get("uri")
-        + " repoMethod="
-        + (repoMethod == null ? "" : repoMethod)
-        + " */"
+    String repoMethod = Objects.requireNonNullElse(RepoMethodContext.resolve(), "");
+    return "/* reqId=%s uri=%s repoMethod=%s%s */"
+            .formatted(reqId, MDC.get("uri"), repoMethod, modeTag)
         + sql;
   }
 }

--- a/modules/global/src/main/java/com/icc/qasker/global/query/QueryInstrumentationConfig.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/query/QueryInstrumentationConfig.java
@@ -3,6 +3,7 @@ package com.icc.qasker.global.query;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
 import org.hibernate.cfg.AvailableSettings;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,11 +12,11 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
- * 부하 테스트 전용 쿼리 계측 배선. Hibernate에 CountingInspector를 꽂고, 요청 라이프사이클에 QueryCountInterceptor를
- * 등록한다. @Profile("loadtest")이라 부하 테스트 프로파일에서만 로드되고, 일반 local·prod에는 영향이 없다.
+ * 로컬 측정 전용 쿼리 계측 배선. Hibernate에 CountingInspector를 꽂고, 요청 라이프사이클에 QueryCountInterceptor를
+ * 등록한다. @Profile("local")이라 로컬 프로파일에서만 로드되고, prod에는 영향이 없다.
  */
 @Configuration
-@Profile("loadtest")
+@Profile("local")
 public class QueryInstrumentationConfig implements WebMvcConfigurer {
 
   private final MeterRegistry meterRegistry;
@@ -24,15 +25,21 @@ public class QueryInstrumentationConfig implements WebMvcConfigurer {
     this.meterRegistry = meterRegistry;
   }
 
-  /** Hibernate SessionFactory에 StatementInspector를 등록 — 모든 SQL이 inspect()를 거친다. */
+  /**
+   * Hibernate SessionFactory에 StatementInspector를 등록 — 모든 SQL이 inspect()를 거친다.
+   *
+   * @param mode 인핸스먼트 A/B 런이 주는 모드 태그(run.sh의 MANAGEMENT_METRICS_TAGS_MODE). 일반 로컬 구동에선 비어 있어 주석에
+   *     붙지 않는다.
+   */
   @Bean
-  public HibernatePropertiesCustomizer statementInspectorCustomizer() {
-    CountingInspector inspector = new CountingInspector();
+  public HibernatePropertiesCustomizer statementInspectorCustomizer(
+      @Value("${management.metrics.tags.mode:}") String mode) {
+    CountingInspector inspector = new CountingInspector(mode);
     return (Map<String, Object> props) ->
         props.put(AvailableSettings.STATEMENT_INSPECTOR, inspector);
   }
 
-  /** reqId·uri를 MDC에 싣는 필터. @Profile("loadtest")이라 부하 테스트 때만 체인에 오른다. */
+  /** reqId·uri를 MDC에 싣는 필터. @Profile("local")이라 로컬에서만 체인에 오른다. */
   @Bean
   public MdcRequestFilter mdcRequestFilter() {
     return new MdcRequestFilter();

--- a/modules/global/src/main/java/com/icc/qasker/global/query/RepoMethodAspect.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/query/RepoMethodAspect.java
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Component;
 
 /**
  * Spring Data 레포 메서드 호출을 가로채, "레포.메서드"(repoMethod)를 RepoMethodContext에 싣는다. CountingInspector가 이 값을
- * SQL 주석의 repoMethod=에 붙인다. @Profile("loadtest") 전용.
+ * SQL 주석의 repoMethod=에 붙인다. @Profile("local") 전용.
  */
 @Aspect
 @Component
-@Profile("loadtest")
+@Profile("local")
 public class RepoMethodAspect {
 
   @Around("this(org.springframework.data.repository.Repository)")

--- a/modules/global/src/main/java/com/icc/qasker/global/query/ScheduledTraceAspect.java
+++ b/modules/global/src/main/java/com/icc/qasker/global/query/ScheduledTraceAspect.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  */
 @Aspect
 @Component
-@Profile("loadtest")
+@Profile("local")
 public class ScheduledTraceAspect {
 
   @Around("@annotation(org.springframework.scheduling.annotation.Scheduled)")

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/scheduler/StaleGenerationRecoveryScheduler.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/scheduler/StaleGenerationRecoveryScheduler.java
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Component;
 
 /**
  * 방치된 ProblemSet을 주기적으로 정리한다. 실제 정리 로직은 {@link StaleGenerationRecoveryService}에 있고 여기서는 주기 발화만
- * 담당한다. loadtest 프로파일에서는 타이머를 비활성화한다 — 부하 트레이스가 순증 0을 유지하도록 백그라운드 삭제를 막는다(로직은 온디맨드 트리거가 호출).
+ * 담당한다. local 프로파일에서는 타이머를 비활성화한다 — 부하 트레이스가 순증 0을 유지하도록 백그라운드 삭제를 막는다(로직은 온디맨드 트리거가 호출).
  */
 @Slf4j
 @Component
-@Profile("!loadtest")
+@Profile("!local")
 @RequiredArgsConstructor
 public class StaleGenerationRecoveryScheduler {
 


### PR DESCRIPTION
## 개요
query-tuning 측정 하네스가 읽는 **인앱 쿼리 계측 인프라**를 확장한다. 전부 `@Profile("local")`이라 prod 에는 로드되지 않는다. 하네스 스크립트(별도 작업)와 독립이며 이 PR만으로 컴파일·동작한다.

## 변경
- **RequestResourceMetricsFilter / Config** — 요청 스레드의 CPU 시간·힙 할당 바이트 델타를 uri별 카운터(`request.thread.cpu.seconds`·`request.thread.allocated.bytes`)로 누적. 플랫폼 스레드+동기 MVC 전제(가상 스레드에선 무효).
- **JfrMethodTimingExporter (신규)** — JEP 520 `jdk.MethodTiming` 이벤트를 JFR 스트리밍으로 구독해 게이지(`jfr.method.invocations`·`jfr.method.time.total`)로 노출. 하네스 MT_FILTER 6종과 동기.
- **CountingInspector · RepoMethodAspect · ScheduledTraceAspect · QueryInstrumentationConfig** — SQL 주석 주입·레포 귀속 트레이스 보강.
- **LocalSchedulerController · StaleGenerationRecoveryScheduler** — 온디맨드 스케줄러 훅 정리.

## 영향
- 런타임 프로파일: `local` 전용. prod 무영향.
- 신규 의존성 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
