### PR TITLE
♻️ refactor: 해설 재검토를 setId 배치 처리로 전환

### DIFF
--- a/modules/admin/src/main/java/com/icc/qasker/admin/controller/AdminController.java
+++ b/modules/admin/src/main/java/com/icc/qasker/admin/controller/AdminController.java
@@ -66,7 +66,7 @@ public class AdminController {
   public ResponseEntity<List<ExplanationReviewResult>> requestExplanationReview(
       @RequestBody Map<String, List<Long>> body) {
     List<Long> setIds = body.getOrDefault("setIds", List.of());
-    return ResponseEntity.ok(setIds.stream().map(explanationReviewService::review).toList());
+    return ResponseEntity.ok(explanationReviewService.review(setIds));
   }
 
   @Operation(summary = "업데이트 로그를 작성한다")

--- a/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/ExplanationReviewService.java
+++ b/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/ExplanationReviewService.java
@@ -1,6 +1,7 @@
 package com.icc.qasker.quizset;
 
 import com.icc.qasker.quizset.dto.ExplanationReviewResult;
+import java.util.List;
 
 /**
  * 해설 형식 검증(정규식) 온디맨드 서비스. 품질 로그의 해설(개선본 v2 우선, 없으면 첫 생성본 v1)을 정형 규칙으로 검증하고, 형식 위반 문항의 review 컬럼에만
@@ -8,6 +9,6 @@ import com.icc.qasker.quizset.dto.ExplanationReviewResult;
  */
 public interface ExplanationReviewService {
 
-  /** 세트의 해설 형식을 검증하고 위반 문항의 review를 마킹한다. */
-  ExplanationReviewResult review(Long problemSetId);
+  /** 여러 세트의 해설 형식을 한 트랜잭션에서 검증하고 위반 문항의 review를 마킹한다. 결과는 요청한 세트 순서로 돌려준다. */
+  List<ExplanationReviewResult> review(List<Long> problemSetIds);
 }

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/quality/ExplanationReviewServiceImpl.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/quality/ExplanationReviewServiceImpl.java
@@ -6,13 +6,19 @@ import com.icc.qasker.quizset.ExplanationReviewService;
 import com.icc.qasker.quizset.dto.ExplanationReviewResult;
 import com.icc.qasker.quizset.entity.ProblemQualityLog;
 import com.icc.qasker.quizset.repository.ProblemQualityLogRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * 해설 형식 검증(정규식) 온디맨드 구현. 로그 행의 해설(개선본 v2 우선, 없으면 첫 생성본 v1)을 {@link ExplanationFormatValidator}로
  * 검증하고, 필수 규칙 미달 문항의 review에만 위반 요약을 마킹한다(dirty subset). 통과분은 무변경, 서빙 problem은 건드리지 않는다.
+ *
+ * <p>요청한 세트 전부를 한 SELECT로 읽고 한 트랜잭션에서 처리한다 — 세트 수만큼 왕복하던 SELECT·COMMIT·autocommit 토글이 1회로 준다. 대신 한
+ * 세트라도 대상이 없으면 요청 전체가 롤백된다(부분 커밋 없음).
  */
 @Service
 public class ExplanationReviewServiceImpl implements ExplanationReviewService {
@@ -31,28 +37,36 @@ public class ExplanationReviewServiceImpl implements ExplanationReviewService {
   }
 
   @Override
-  public ExplanationReviewResult review(Long problemSetId) {
-    return transactionTemplate.execute(status -> doReview(problemSetId));
+  public List<ExplanationReviewResult> review(List<Long> problemSetIds) {
+    return transactionTemplate.execute(status -> doReview(problemSetIds));
   }
 
-  private ExplanationReviewResult doReview(Long problemSetId) {
-    List<ProblemQualityLog> logs = qualityLogRepository.findByProblemSetIdIn(List.of(problemSetId));
-    if (logs.isEmpty()) {
-      throw new CustomException(ExceptionMessage.QUALITY_REVIEW_NO_TARGET);
-    }
+  private List<ExplanationReviewResult> doReview(List<Long> problemSetIds) {
+    Map<Long, List<ProblemQualityLog>> logsBySet =
+        qualityLogRepository.findByProblemSetIdIn(problemSetIds).stream()
+            .collect(Collectors.groupingBy(ProblemQualityLog::getProblemSetId));
 
-    int violations = 0;
-    for (ProblemQualityLog log : logs) {
-      String explanation =
-          log.getV2Explanation() != null ? log.getV2Explanation() : log.getV1Explanation();
-      ExplanationFormatValidator.Result result = validator.validate(explanation);
-
-      if (!result.passed()) {
-        // 형식 미달 문항만 review 마킹 → dirty subset. 통과분은 무변경(flush 스킵).
-        log.markExplanationReview(result.summary());
-        violations++;
+    List<ExplanationReviewResult> results = new ArrayList<>(problemSetIds.size());
+    for (Long problemSetId : problemSetIds) {
+      List<ProblemQualityLog> logs = logsBySet.get(problemSetId);
+      if (logs == null) {
+        throw new CustomException(ExceptionMessage.QUALITY_REVIEW_NO_TARGET);
       }
+
+      int violations = 0;
+      for (ProblemQualityLog log : logs) {
+        String explanation =
+            log.getV2Explanation() != null ? log.getV2Explanation() : log.getV1Explanation();
+        ExplanationFormatValidator.Result result = validator.validate(explanation);
+
+        if (!result.passed()) {
+          // 형식 미달 문항만 review 마킹 → dirty subset. 통과분은 무변경(flush 스킵).
+          log.markExplanationReview(result.summary());
+          violations++;
+        }
+      }
+      results.add(new ExplanationReviewResult(problemSetId, logs.size(), violations));
     }
-    return new ExplanationReviewResult(problemSetId, logs.size(), violations);
+    return results;
   }
 }

--- a/modules/quiz-set/impl/src/test/java/com/icc/qasker/quizset/service/quality/ExplanationReviewServiceTest.java
+++ b/modules/quiz-set/impl/src/test/java/com/icc/qasker/quizset/service/quality/ExplanationReviewServiceTest.java
@@ -64,7 +64,7 @@ class ExplanationReviewServiceTest extends JpaIntegrationTestBase {
     flushAndClear();
 
     statistics().clear();
-    ExplanationReviewResult result = service.review(setId);
+    ExplanationReviewResult result = service.review(java.util.List.of(setId)).get(0);
     flushAndClear();
 
     assertThat(result.reviewedCount()).isEqualTo(3);
@@ -90,7 +90,7 @@ class ExplanationReviewServiceTest extends JpaIntegrationTestBase {
     em.persist(row);
     flushAndClear();
 
-    ExplanationReviewResult result = service.review(setId);
+    ExplanationReviewResult result = service.review(java.util.List.of(setId)).get(0);
     flushAndClear();
 
     assertThat(result.violationCount()).isEqualTo(1);


### PR DESCRIPTION
## 개요
해설 재검토(explanation-review) 어드민 엔드포인트를 **setId 배치 처리**로 전환한다.

## 변경
- `AdminController` — `setIds` 를 하나씩 `review()` 호출하던 것을 배치 시그니처 `review(List<Long>)` **한 번 호출**로 변경.
- `ExplanationReviewService`(api) · `ExplanationReviewServiceImpl` — 시그니처를 `List<Long>` 배치로 변경.
- 테스트 동기화(`ExplanationReviewServiceTest`).

## 효과
세트별 개별 호출 → 배치 1회로, N개 세트 재검토 시 왕복·오버헤드 감소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
