### PR TITLE
🔧 chore: 로컬 토큰 발급 local 프로파일 확장 + .gitignore 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
@@ -50,18 +49,12 @@ out/
 !**/src/main/resources/application-secrets.yml
 .env
 app/gradle.properties
-app/newrelic/newrelic.yml
 **/heapdump
-monitor_downtime.sh
+docs
 
 # Claude Code
-shrimp-rules.md
+CLAUDE.local.md
 .mcp.json
 .claude
 .specify
 /specs
-shrimp_data
-docs
-
-# Gemini CLI
-.gemini

--- a/modules/auth/impl/src/main/java/com/icc/qasker/auth/controller/LocalTokenController.java
+++ b/modules/auth/impl/src/main/java/com/icc/qasker/auth/controller/LocalTokenController.java
@@ -12,8 +12,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 로컬/부하 전용 JWT 발급 헬퍼. {@code GET /local/token?userId=} 로 기존 User의 액세스 토큰을 즉시 발급해 OAuth 로그인 없이 인증이
+ * 필요한 API(E2E·수동 테스트·부하)를 태울 수 있게 한다.
+ *
+ * <p>{@code local} 프로파일에서만 빈으로 등록된다. {@code prod} 에는 절대 노출되지 않는다(프로파일 게이트).
+ */
 @RestController
-@Profile("loadtest")
+@Profile("local")
 @RequiredArgsConstructor
 @RequestMapping("/local")
 public class LocalTokenController {


### PR DESCRIPTION
## 개요
로컬 개발·E2E 편의 도구 2건. 하네스 PR(#411)에서 의도적으로 뺐던 커밋 중 **기능적으로 유효한 것만** 추려 별도 PR로 올린다(revert·문서-only 커밋은 제외).

## 변경
- **LocalTokenController `@Profile("loadtest")` → `@Profile("local")`** — 로그인 우회 토큰 발급(`GET /local/token?userId=`)을 `local` 프로파일에서도 쓸 수 있게 확장. loadtest 는 항상 `local` 위에 얹혀 실행되므로 부하 테스트에서도 그대로 활성. 로컬 개발·**E2E**에서 로그인 없이 인증 API 를 태울 때 사용. prod 노출 없음.
- **.gitignore 정리** — stale 항목(HELP.md·app/newrelic·monitor_downtime.sh·shrimp·.gemini 등) 제거, `CLAUDE.local.md`·`docs` 무시 추가.

## 참고
- 원커밋(`d70901f7`)엔 JWT 작업 가이드 CLAUDE.md 문서도 있었으나, **그 문서는 develop 에 이미 반영돼 있어** 이 PR 엔 코드 변경(LocalTokenController)만 포함된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
