### PR TITLE
🐛 fix(oci): mock 프로필에서 OCI 클라이언트 빈 제외 — 부팅 시 ~/.oci 요구 제거

### DIFF
--- a/modules/oci/impl/src/main/java/com/icc/qasker/oci/config/MockOciClientConfig.java
+++ b/modules/oci/impl/src/main/java/com/icc/qasker/oci/config/MockOciClientConfig.java
@@ -11,10 +11,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
-/** stress-test 및 test 프로파일에서 실제 OCI 연결 없이 업로드를 시뮬레이션한다. */
+/** stress-test·test·mock 프로파일에서 실제 OCI 연결 없이 업로드를 시뮬레이션한다. */
 @Slf4j
 @Configuration
-@Profile({"stress-test", "test"})
+@Profile({"stress-test", "test", "mock"})
 public class MockOciClientConfig {
 
   @Bean

--- a/modules/oci/impl/src/main/java/com/icc/qasker/oci/config/OciObjectStorageConfig.java
+++ b/modules/oci/impl/src/main/java/com/icc/qasker/oci/config/OciObjectStorageConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile("!stress-test & !test")
+@Profile("!stress-test & !test & !mock")
 public class OciObjectStorageConfig {
 
   private final OciObjectStorageProperties properties;


### PR DESCRIPTION
mock 프로필이 외부 '호출'은 막았지만 ObjectStorageClient '빈 생성'은 못 막아, ~/.oci/config 없는 환경(백업 복원 리허설의 앱 부팅 검증)에서
컨텍스트가 죽었다. stress-test·test와 동일하게 mock도 실클라이언트
제외 + MockOciClientConfig 대체 적용.

<!-- prettier-ignore-start -->

## 📢 설명

### 변경 1: [제목]

[변경에 대한 설명]

#### 의사 선택과정 (trade-off)

> trade-off가 있는 경우에만 작성

**얻은 것**
-

**잃은 것**
-

### 코드 설명: 인라인 코멘트 확인

## ✅ 체크 리스트

### 재현 확인

<!-- 리뷰어가 직접 따라하며 변경사항을 확인할 수 있는 단계 -->

- [ ] (PR 작성 시 채워주세요)

### 기본

- [ ] 의사 선택 과정이 적절한지 확인
- [ ] 코드 리뷰

---
<!-- prettier-ignore-end -->
