### PR TITLE
[006] 같은 조건으로 문제 이어서 더 풀기 — 백엔드

### DIFF
--- a/app/src/main/resources/db/migration/V18__add_page_numbers_and_language_to_problem_set.sql
+++ b/app/src/main/resources/db/migration/V18__add_page_numbers_and_language_to_problem_set.sql
@@ -1,0 +1,10 @@
+-- 동일 재현(이어풀기)용 생성 조건 보강: 세트가 pageNumbers·language를 소유해 조회 시 되짚을 수 있게 한다.
+-- 기존 legacy 행은 두 값 NULL → 조회 응답에서 폴백(US2)으로 유도된다.
+ALTER TABLE problem_set
+    ADD COLUMN page_numbers TEXT NULL,
+    ADD COLUMN language VARCHAR(8) NULL;
+
+-- PII 분류(새 컬럼 커버리지 게이트) — 페이지 번호 목록·언어 코드는 개인정보 아님.
+INSERT INTO pii_classification (table_name, column_name, strategy, note)
+VALUES ('problem_set', 'page_numbers', 'SAFE', NULL),
+       ('problem_set', 'language', 'SAFE', NULL);

--- a/modules/quiz-make/impl/src/main/java/com/icc/qasker/quizmake/service/generation/GenerationCommandServiceImpl.java
+++ b/modules/quiz-make/impl/src/main/java/com/icc/qasker/quizmake/service/generation/GenerationCommandServiceImpl.java
@@ -62,7 +62,9 @@ public class GenerationCommandServiceImpl implements GenerationCommandService {
               request.quizCount(),
               request.quizType(),
               request.uploadedUrl(),
-              request.customInstruction());
+              request.customInstruction(),
+              request.pageNumbers(),
+              request.language().name());
     } catch (DataIntegrityViolationException e) {
       throw new CustomException(ExceptionMessage.AI_DUPLICATED_GENERATION);
     }

--- a/modules/quiz-make/impl/src/main/java/com/icc/qasker/quizmake/service/mock/MockGenerationCommandService.java
+++ b/modules/quiz-make/impl/src/main/java/com/icc/qasker/quizmake/service/mock/MockGenerationCommandService.java
@@ -37,7 +37,9 @@ public class MockGenerationCommandService implements GenerationCommandService {
         request.quizCount(),
         request.quizType(),
         request.uploadedUrl(),
-        request.customInstruction());
+        request.customInstruction(),
+        request.pageNumbers(),
+        request.language().name());
     // 자기정리: 롤백으로 problem_set INSERT를 되돌린다(트레이스엔 남고 DB엔 안 남음).
     TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
   }

--- a/modules/quiz-make/impl/src/test/java/com/icc/qasker/quizmake/service/generation/GenerationCommandServiceImplTest.java
+++ b/modules/quiz-make/impl/src/test/java/com/icc/qasker/quizmake/service/generation/GenerationCommandServiceImplTest.java
@@ -53,7 +53,8 @@ class GenerationCommandServiceImplTest {
     hashUtil = mock(HashUtil.class);
     resultRecorder = mock(GenerationResultRecorder.class);
 
-    when(quizCommandService.initProblemSet(any(), any(), any(), anyInt(), any(), any(), any()))
+    when(quizCommandService.initProblemSet(
+            any(), any(), any(), anyInt(), any(), any(), any(), any(), any()))
         .thenReturn(1L);
 
     service =
@@ -76,7 +77,15 @@ class GenerationCommandServiceImplTest {
 
     verify(quizCommandService, timeout(2000))
         .initProblemSet(
-            eq("user-1"), any(), any(), anyInt(), eq(QuizType.REAL_BLANK), any(), any());
+            eq("user-1"),
+            any(),
+            any(),
+            anyInt(),
+            eq(QuizType.REAL_BLANK),
+            any(),
+            any(),
+            any(),
+            any());
   }
 
   @Test

--- a/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/ProblemSetService.java
+++ b/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/ProblemSetService.java
@@ -3,10 +3,13 @@ package com.icc.qasker.quizset;
 import com.icc.qasker.quizset.dto.ferequest.ChangeTitleRequest;
 import com.icc.qasker.quizset.dto.feresponse.ChangeTitleResponse;
 import com.icc.qasker.quizset.dto.feresponse.ProblemSetResponse;
+import com.icc.qasker.quizset.dto.feresponse.RegenerationConditionResponse;
 
 public interface ProblemSetService {
 
   ProblemSetResponse getProblemSet(String problemSetId);
+
+  RegenerationConditionResponse getRegenerationCondition(String problemSetId);
 
   ChangeTitleResponse changeProblemSetTitle(
       String userId, String problemSetId, ChangeTitleRequest request);

--- a/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/QuizCommandService.java
+++ b/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/QuizCommandService.java
@@ -13,7 +13,9 @@ public interface QuizCommandService {
       Integer totalQuizCount,
       QuizType quizType,
       String uploadUrl,
-      String customInstruction);
+      String customInstruction,
+      List<Integer> pageNumbers,
+      String language);
 
   void updateStatus(Long problemSetId, GenerationStatus status);
 

--- a/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/dto/feresponse/RegenerationConditionResponse.java
+++ b/modules/quiz-set/api/src/main/java/com/icc/qasker/quizset/dto/feresponse/RegenerationConditionResponse.java
@@ -1,0 +1,21 @@
+package com.icc.qasker.quizset.dto.feresponse;
+
+import com.icc.qasker.quizset.dto.ferequest.enums.QuizType;
+import java.util.List;
+
+/**
+ * 세트의 생성 조건을 되돌려주는 응답(동일 재현·이어풀기용). 즉시생성 vs 옵션 화면 폴백의 판정은 프론트가 {@code documentAvailable &&
+ * pageNumbers?.length && language}로 수행한다(서버에 reproducible 집계 플래그를 두지 않아 계약이 얇다).
+ *
+ * <p>{@code documentAvailable}은 원본 자료가 지금 유효한지의 서버 소유 판정 자리다. 자료 능동 만료검사는 이번 스코프에서 미도입(후속 과제)이라 현
+ * 단계 항상 {@code true}. legacy 세트(pageNumbers·language 미저장)는 두 값이 null로 내려가 프론트 폴백으로 유도된다.
+ */
+public record RegenerationConditionResponse(
+    QuizType quizType,
+    Integer quizCount,
+    List<Integer> pageNumbers,
+    String language,
+    String customInstruction,
+    String uploadedUrl,
+    String title,
+    boolean documentAvailable) {}

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/controller/ProblemSetQueryController.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/controller/ProblemSetQueryController.java
@@ -2,6 +2,7 @@ package com.icc.qasker.quizset.controller;
 
 import com.icc.qasker.quizset.ProblemSetService;
 import com.icc.qasker.quizset.dto.feresponse.ProblemSetResponse;
+import com.icc.qasker.quizset.dto.feresponse.RegenerationConditionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,12 @@ public class ProblemSetQueryController {
   @GetMapping("/{id}")
   public ResponseEntity<ProblemSetResponse> getProblemSet(@PathVariable("id") String problemSetId) {
     return ResponseEntity.ok(problemSetService.getProblemSet(problemSetId));
+  }
+
+  @Operation(summary = "세트의 생성 조건을 되돌려준다(동일 재현·이어풀기용)")
+  @GetMapping("/{id}/regeneration-condition")
+  public ResponseEntity<RegenerationConditionResponse> getRegenerationCondition(
+      @PathVariable("id") String problemSetId) {
+    return ResponseEntity.ok(problemSetService.getRegenerationCondition(problemSetId));
   }
 }

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/entity/ProblemSet.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/entity/ProblemSet.java
@@ -2,8 +2,10 @@ package com.icc.qasker.quizset.entity;
 
 import com.icc.qasker.global.entity.CreatedAt;
 import com.icc.qasker.quizset.GenerationStatus;
+import com.icc.qasker.quizset.converter.IntegerListConverter;
 import com.icc.qasker.quizset.dto.ferequest.enums.QuizType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -61,6 +63,16 @@ public class ProblemSet extends CreatedAt {
 
   @Column(columnDefinition = "TEXT")
   private String customInstruction;
+
+  // 동일 재현(이어풀기)용 생성 조건 — 생성 시점에만 알 수 있어 세트에 함께 저장한다(일반 조회 응답엔 없어 복원 불가).
+  // V18 이전 legacy 세트는 컬럼 NULL. IntegerListConverter는 NULL을 빈 리스트로 읽으므로 조회 매핑에서 빈 리스트를 null로 정규화한다.
+  @Convert(converter = IntegerListConverter.class)
+  @Column(columnDefinition = "TEXT")
+  private List<Integer> pageNumbers;
+
+  // 요청 Language enum(quiz-make 모듈)을 이 모듈이 의존하지 않아 문자열("KO"/"EN")로 저장한다.
+  @Column(length = 8)
+  private String language;
 
   // 이하 헬퍼 함수
   public void updateStatus(GenerationStatus status) {

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/generation/support/QuizCommandServiceImpl.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/generation/support/QuizCommandServiceImpl.java
@@ -33,7 +33,9 @@ public class QuizCommandServiceImpl implements QuizCommandService {
       Integer totalQuizCount,
       QuizType quizType,
       String uploadUrl,
-      String customInstruction) {
+      String customInstruction,
+      List<Integer> pageNumbers,
+      String language) {
     ProblemSet problemSet =
         ProblemSet.builder()
             .sessionId(sessionId)
@@ -43,6 +45,8 @@ public class QuizCommandServiceImpl implements QuizCommandService {
             .quizType(quizType)
             .fileUrl(uploadUrl)
             .customInstruction(customInstruction)
+            .pageNumbers(pageNumbers)
+            .language(language)
             .build();
     ProblemSet saved = problemSetRepository.save(problemSet);
     return saved.getId();

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/mock/MockProblemSetService.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/mock/MockProblemSetService.java
@@ -4,6 +4,7 @@ import com.icc.qasker.quizset.ProblemSetService;
 import com.icc.qasker.quizset.dto.ferequest.ChangeTitleRequest;
 import com.icc.qasker.quizset.dto.feresponse.ChangeTitleResponse;
 import com.icc.qasker.quizset.dto.feresponse.ProblemSetResponse;
+import com.icc.qasker.quizset.dto.feresponse.RegenerationConditionResponse;
 import com.icc.qasker.quizset.entity.ProblemSet;
 import com.icc.qasker.quizset.repository.ProblemSetRepository;
 import com.icc.qasker.quizset.service.query.ProblemSetServiceImpl;
@@ -32,6 +33,11 @@ public class MockProblemSetService implements ProblemSetService {
   @Override
   public ProblemSetResponse getProblemSet(String problemSetId) {
     return real.getProblemSet(problemSetId);
+  }
+
+  @Override
+  public RegenerationConditionResponse getRegenerationCondition(String problemSetId) {
+    return real.getRegenerationCondition(problemSetId);
   }
 
   @Override

--- a/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/query/ProblemSetServiceImpl.java
+++ b/modules/quiz-set/impl/src/main/java/com/icc/qasker/quizset/service/query/ProblemSetServiceImpl.java
@@ -7,9 +7,11 @@ import com.icc.qasker.quizset.ProblemSetService;
 import com.icc.qasker.quizset.dto.ferequest.ChangeTitleRequest;
 import com.icc.qasker.quizset.dto.feresponse.ChangeTitleResponse;
 import com.icc.qasker.quizset.dto.feresponse.ProblemSetResponse;
+import com.icc.qasker.quizset.dto.feresponse.RegenerationConditionResponse;
 import com.icc.qasker.quizset.entity.ProblemSet;
 import com.icc.qasker.quizset.mapper.ProblemSetResponseMapper;
 import com.icc.qasker.quizset.repository.ProblemSetRepository;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,27 @@ public class ProblemSetServiceImpl implements ProblemSetService {
     Assert.hasText(problemSetId, "problemSetId must not be blank");
     ProblemSet problemSet = getProblemSetEntityByEncoded(problemSetId);
     return problemSetResponseMapper.fromEntity(problemSet);
+  }
+
+  @Override
+  public RegenerationConditionResponse getRegenerationCondition(String problemSetId) {
+    Assert.hasText(problemSetId, "problemSetId must not be blank");
+    ProblemSet ps = getProblemSetEntityByEncoded(problemSetId);
+    // 자료 능동 만료검사는 이번 스코프 미도입 → documentAvailable 항상 true(후속에 실 판정으로 대체).
+    return new RegenerationConditionResponse(
+        ps.getQuizType(),
+        ps.getTotalQuizCount(),
+        emptyToNull(ps.getPageNumbers()),
+        ps.getLanguage(),
+        ps.getCustomInstruction(),
+        ps.getFileUrl(),
+        ps.getTitle(),
+        true);
+  }
+
+  // legacy 세트는 컬럼 NULL이 IntegerListConverter를 거쳐 빈 리스트로 읽힌다. 계약대로 null로 정규화해 프론트 폴백 판정을 명확히 한다.
+  private static List<Integer> emptyToNull(List<Integer> pageNumbers) {
+    return (pageNumbers == null || pageNumbers.isEmpty()) ? null : pageNumbers;
   }
 
   @Override

--- a/modules/quiz-set/impl/src/test/java/com/icc/qasker/quizset/service/query/ProblemSetServiceImplTest.java
+++ b/modules/quiz-set/impl/src/test/java/com/icc/qasker/quizset/service/query/ProblemSetServiceImplTest.java
@@ -12,6 +12,7 @@ import com.icc.qasker.quizset.TestEntityFactory;
 import com.icc.qasker.quizset.dto.ferequest.ChangeTitleRequest;
 import com.icc.qasker.quizset.dto.ferequest.enums.QuizType;
 import com.icc.qasker.quizset.dto.feresponse.ChangeTitleResponse;
+import com.icc.qasker.quizset.dto.feresponse.RegenerationConditionResponse;
 import com.icc.qasker.quizset.entity.ProblemSet;
 import com.icc.qasker.quizset.mapper.ProblemSetResponseMapper;
 import com.icc.qasker.quizset.repository.ProblemSetRepository;
@@ -77,5 +78,74 @@ class ProblemSetServiceImplTest {
             () -> service.changeProblemSetTitle("user-1", "enc", new ChangeTitleRequest("x")))
         .isInstanceOf(CustomException.class)
         .hasMessage(ExceptionMessage.NOT_ENOUGH_ACCESS.getMessage());
+  }
+
+  @Test
+  @DisplayName("조건이 온전한 세트는 저장 조건을 그대로 되돌려주고 documentAvailable=true (effective quizType 유지)")
+  void returns_regeneration_condition_for_complete_set() {
+    ProblemSet set =
+        ProblemSet.builder()
+            .id(1L)
+            .sessionId("sess")
+            .title("이산수학 3장")
+            .generationStatus(GenerationStatus.COMPLETED)
+            .quizType(QuizType.REAL_BLANK)
+            .totalQuizCount(10)
+            .userId("user-1")
+            .fileUrl("https://cdn.example/doc.pdf")
+            .customInstruction("난이도 높게")
+            .pageNumbers(List.of(1, 2, 3))
+            .language("KO")
+            .build();
+    when(hashUtil.decode("enc")).thenReturn(1L);
+    when(problemSetRepository.findById(1L)).thenReturn(Optional.of(set));
+
+    RegenerationConditionResponse response = service.getRegenerationCondition("enc");
+
+    assertThat(response.quizType()).isEqualTo(QuizType.REAL_BLANK);
+    assertThat(response.quizCount()).isEqualTo(10);
+    assertThat(response.pageNumbers()).containsExactly(1, 2, 3);
+    assertThat(response.language()).isEqualTo("KO");
+    assertThat(response.customInstruction()).isEqualTo("난이도 높게");
+    assertThat(response.uploadedUrl()).isEqualTo("https://cdn.example/doc.pdf");
+    assertThat(response.title()).isEqualTo("이산수학 3장");
+    assertThat(response.documentAvailable()).isTrue();
+  }
+
+  @Test
+  @DisplayName("legacy 세트(pageNumbers 빈 리스트·language null)는 두 값을 null로 정규화해 폴백을 유도한다")
+  void normalizes_legacy_set_conditions_to_null() {
+    ProblemSet legacy =
+        ProblemSet.builder()
+            .id(1L)
+            .sessionId("sess")
+            .title("옛 세트")
+            .generationStatus(GenerationStatus.COMPLETED)
+            .quizType(QuizType.MULTIPLE)
+            .totalQuizCount(5)
+            .userId("user-1")
+            .fileUrl("https://cdn.example/old.pdf")
+            .pageNumbers(List.of()) // 컬럼 NULL → IntegerListConverter가 빈 리스트로 읽는다
+            .language(null)
+            .build();
+    when(hashUtil.decode("enc")).thenReturn(1L);
+    when(problemSetRepository.findById(1L)).thenReturn(Optional.of(legacy));
+
+    RegenerationConditionResponse response = service.getRegenerationCondition("enc");
+
+    assertThat(response.pageNumbers()).isNull();
+    assertThat(response.language()).isNull();
+    assertThat(response.documentAvailable()).isTrue();
+  }
+
+  @Test
+  @DisplayName("세트가 없으면 PROBLEM_SET_NOT_FOUND")
+  void throws_when_set_not_found_for_regeneration_condition() {
+    when(hashUtil.decode("enc")).thenReturn(1L);
+    when(problemSetRepository.findById(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getRegenerationCondition("enc"))
+        .isInstanceOf(CustomException.class)
+        .hasMessage(ExceptionMessage.PROBLEM_SET_NOT_FOUND.getMessage());
   }
 }


### PR DESCRIPTION
# [006] 같은 조건으로 문제 이어서 더 풀기 — 백엔드

## 요약

결과·해설 확인 지점에서 방금 푼 세트와 **같은 조건으로 새 세트를 이어 생성**(동일 재현, US1)할 수 있도록,
세트가 자기 생성 조건을 온전히 소유하게 하고 그 조건을 되돌려주는 조회 통로를 낸다. 조건·자료가
소실된 경우(US2)는 조회 응답의 `null` 필드로 프론트 폴백을 유도한다.

핵심 설계(팀 발산·P2P 수렴 + 사용자 결정으로 확정한 `contract.md §확정 인터페이스`):

- **조건 진실 원천 = `ProblemSet`.** 기존에 저장되던 `quizType·totalQuizCount·customInstruction·fileUrl`에
  더해 `page_numbers·language`를 새로 영속화(마이그레이션 V18). 세트가 생성 6종 조건을 자기 소유하게 되어
  기록 재진입·시간 경과와 무관하게 되짚기가 가능하다.
- **재현 트리거는 전용 엔드포인트를 새로 만들지 않고 기존 `POST /generation`을 재사용.** 프론트가 조건을
  조회해 새 `sessionId`와 함께 재전송한다. 결과는 독립된 새 세트(새 id·sessionId)라 드릴 루프(FR-005)와
  기록 구분이 공짜로 성립하고, SSE·진행 UI를 그대로 쓴다. 서버 조건 재구성 로직이 없어 계약이 얇다.
- **즉시생성 vs 폴백 판정은 프론트가 수행**(`documentAvailable && pageNumbers?.length && language`).
  서버는 조건 값만 되돌려 주고 reproducible 집계 플래그를 두지 않는다. legacy 세트(V18 이전)는
  `page_numbers·language`가 `null`로 내려가 자동으로 US2 폴백 대상이 된다.

## 변경 상세

| 파일 | 변경 |
|---|---|
| `db/migration/V18__add_page_numbers_and_language_to_problem_set.sql` | `problem_set`에 `page_numbers TEXT NULL`, `language VARCHAR(8) NULL` 신설 + PII 커버리지 게이트 대응(두 컬럼 `pii_classification`에 `SAFE` 분류) |
| `quizset/entity/ProblemSet.java` | `pageNumbers`(`IntegerListConverter`/TEXT), `language`(String) 필드 추가 |
| `quizset/QuizCommandService.java` (+impl) | `initProblemSet` 시그니처를 `pageNumbers·language`까지 확장 |
| `quizmake/…/GenerationCommandServiceImpl.java`, `…/mock/MockGenerationCommandService.java` | 생성 흐름이 `request.pageNumbers()`·`request.language().name()`을 전달·저장 |
| `quizset/dto/feresponse/RegenerationConditionResponse.java` (신규) | 조건 조회 응답 DTO(8필드) |
| `quizset/ProblemSetService.java` (+impl, +mock) | `getRegenerationCondition` 추가 — 저장 조건 반환, legacy 빈 `pageNumbers`는 `null`로 정규화, `documentAvailable`은 현 스코프 항상 `true` |
| `quizset/…/controller/ProblemSetQueryController.java` | `GET /problem-set/{id}/regeneration-condition` 엔드포인트 |

`document`의 능동 만료검사는 이번 스코프 미도입(사용자 결정) — `documentAvailable`은 서버 소유 판정
자리로 두되 현 단계 항상 `true`. 자료만 만료된 세트의 즉시생성은 생성 시점 SSE `error-finish`로
표면화되고, 프론트가 재시도/재업로드 안내로 처리한다(FR-007).

## API 실물 예시 (기능 E2E·로컬 실행에서 실제 오간 값 — 격리 DB `qasker_e2e_006`)

### `GET /problem-set/{id}/regeneration-condition` (신규)

조회 공개(기존 `getProblemSet`과 동일 정책, 하드 소유권 검증 없음) — **게스트 이어풀기 지원**.

**③ 응답 DTO — 정상 세트**(id=`d2M1pa8v`, 조건 온전 → 즉시생성 경로):

```json
{
  "quizType": "MULTIPLE",
  "quizCount": 5,
  "pageNumbers": [1, 2, 3],
  "language": "KO",
  "customInstruction": "핵심 개념 위주로",
  "uploadedUrl": "https://mock.example/e2e-doc.pdf",
  "title": "이어풀기 E2E 시드 세트",
  "documentAvailable": true
}
```

**③ 응답 DTO — legacy 세트**(id=`PDadlaE4`, 조건 소실 → 폴백 트리거):

```json
{
  "quizType": "MULTIPLE",
  "quizCount": 5,
  "pageNumbers": null,
  "language": null,
  "customInstruction": null,
  "uploadedUrl": "https://mock.example/legacy.pdf",
  "title": "레거시 세트(V18 이전)",
  "documentAvailable": true
}
```

### 재현 트리거 = 기존 `POST /generation` 재사용 (전용 엔드포인트 없음)

**① 요청 DTO** — 프론트가 위 조건 응답값 + 새 `sessionId`로 재전송(→ `202 Accepted`, problemSetId는 SSE `created`로):

```json
{
  "sessionId": "51453e6f-3e84-4bdb-85b2-562acb263e97",
  "uploadedUrl": "https://mock.example/e2e-doc.pdf",
  "title": "이어풀기 E2E 시드 세트",
  "quizCount": 5,
  "quizType": "MULTIPLE",
  "pageNumbers": [1, 2, 3],
  "language": "KO",
  "customInstruction": "핵심 개념 위주로"
}
```

### ② 저장된 실제 DB ROW (`problem_set` — V18 신설 컬럼 실측)

기능 E2E·로컬 재현으로 실제 저장된 행. **정상 세트는 `page_numbers`·`language`가 채워지고**(id 2·3),
legacy 시뮬레이션 행(id 6)은 두 값이 `NULL` — 조회 응답의 `null` 정규화와 정확히 대응한다.

| id | title | quiz_type | total_quiz_count | page_numbers | language | custom_instruction | generation_status |
|----|-------|-----------|------------------|--------------|----------|--------------------|-------------------|
| 2  | 이어풀기 E2E 시드 세트 | MULTIPLE | 5 | `[1,2,3]` | `KO` | 핵심 개념 위주로 | COMPLETED |
| 3  | 이어풀기 E2E 시드 세트 | MULTIPLE | 5 | `[1,2,3]` | `KO` | 핵심 개념 위주로 | COMPLETED |
| 6  | 레거시 세트(V18 이전) | MULTIPLE | 5 | `NULL` | `NULL` | `NULL` | COMPLETED |

> id=2는 이어풀기의 원본 시드 세트, id=3은 그 세트를 이어풀어 만든 **독립된 새 세트**(같은 조건·다른
> id — SC-003 조건 100% 일치 + FR-005 드릴 루프 실증). 조건은 AI 생성 성공 여부와 무관하게
> `initProblemSet` 시점에 저장된다.

## 테스트·기능 E2E 결과

- **새 기능 단위 테스트 3케이스 통과**(`ProblemSetServiceImplTest`):
  ① 조건 온전 세트 되짚기(REAL_BLANK effective 값 유지·`documentAvailable=true`)
  ② legacy(빈 `pageNumbers`·`language` null) → `null` 정규화
  ③ 세트 없음 → `PROBLEM_SET_NOT_FOUND`.
  기존 `GenerationCommandServiceImplTest`도 확장 시그니처(9인자)로 갱신·통과.
- **전체 컴파일 통과**(`compileJava`+`compileTestJava` BUILD SUCCESSFUL), `spotlessCheck` 통과.
- **Flyway V1~V18 전량 적용 성공**(격리 DB에 새로 적용 — 마이그레이션 무결성 실증).
- **기능 E2E `repeat-generation.spec.ts` 2 passed**(@frontend 실행, 백엔드 로컬 기동):
  결과화면 CTA → `GET .../regeneration-condition` → 즉시생성 판정 → `POST /generation`(mockai SSE) →
  `/quiz/{newId}` 자동 진입, `newId ≠ 원본`(FR-005), 원제목 재사용.
  백엔드 자체 스모크: regeneration-condition 계약 8필드, 토큰 없이 `200`(게스트), 재현 조건 100% 일치.

## 관련 제품 결정 (`contract.md §확정 인터페이스`, 2026-07-30 사용자 결정)

1. **게스트 이어풀기 지원** — 로그인 없이 조건 조회·재생성(익명 통과). 재생성 세트 소유자는 요청자.
2. **자료 능동 만료검사 = 이번 스코프 미도입** — `documentAvailable` 항상 `true`, 만료는 SSE 에러로 표면화.
3. **선행 브랜치 `feature/feedback7-repeat-gen` 대체(supersede)** → 마이그레이션 번호 **V18**.
4. **진입 CTA = 결과·해설 양쪽**(프론트 소관).

## 작업 브랜치

`feat/006-repeat-quiz-generation` (base: `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
