### PR TITLE
[fix][BE] quiz_history 저장의 동시성 레이스 흡수 (유니크 충돌 500 제거)

### DIFF
--- a/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImpl.java
+++ b/modules/quiz-history/impl/src/main/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImpl.java
@@ -54,7 +54,6 @@ public class QuizHistoryCommandServiceImpl implements QuizHistoryCommandService 
   }
 
   @Override
-  @Transactional
   public String saveHistory(String userId, SaveHistoryRequest request) {
     Long problemSetId = hashUtil.decode(request.problemSetId());
     List<AnswerSnapshot> snapshots =
@@ -64,19 +63,39 @@ public class QuizHistoryCommandServiceImpl implements QuizHistoryCommandService 
 
     int score = resolveScore(problemSetId, request);
 
-    QuizHistory history =
-        quizHistoryRepository
-            .findByUserIdAndProblemSetId(userId, problemSetId)
-            .orElseGet(
-                () ->
-                    quizHistoryRepository.save(
-                        QuizHistory.builder()
-                            .userId(userId)
-                            .problemSetId(problemSetId)
-                            .title(request.title())
-                            .build()));
+    QuizHistory history = findOrCreateHistory(userId, problemSetId, request.title());
     history.completeQuiz(snapshots, score, request.totalTime());
+    quizHistoryRepository.save(history);
     return hashUtil.encode(history.getId());
+  }
+
+  /**
+   * (user, problemSet) 이력 행을 찾거나 없으면 생성한다. 같은 세트의 결과 화면이 병렬로 열려 이력 저장이 동시에 일어나면 둘 다 INSERT를 시도해 유니크
+   * 제약 {@code (user_id, problem_set_id)}에 걸릴 수 있는데, 충돌을 재조회로 흡수해 500 대신 먼저 만들어진 행을 재사용한다({@link
+   * #initHistory}와 동일 패턴).
+   *
+   * <p>메서드-레벨 {@code @Transactional}을 두지 않는 것이 핵심이다 — 각 리포지토리 호출이 독립 트랜잭션이라 한 요청의 INSERT 충돌이 이 흐름을
+   * 오염시키지 않아 이어지는 재조회가 정상 동작한다(같은 트랜잭션 안에서 잡으면 rollback-only로 오염돼 재조회가 실패한다). 이후 {@code
+   * completeQuiz} 변경은 호출부의 명시적 {@code save}(merge)로 영속한다.
+   */
+  private QuizHistory findOrCreateHistory(String userId, Long problemSetId, String title) {
+    return quizHistoryRepository
+        .findByUserIdAndProblemSetId(userId, problemSetId)
+        .orElseGet(
+            () -> {
+              try {
+                return quizHistoryRepository.save(
+                    QuizHistory.builder()
+                        .userId(userId)
+                        .problemSetId(problemSetId)
+                        .title(title)
+                        .build());
+              } catch (DataIntegrityViolationException e) {
+                return quizHistoryRepository
+                    .findByUserIdAndProblemSetId(userId, problemSetId)
+                    .orElseThrow(() -> new CustomException(ExceptionMessage.PROBLEM_SET_NOT_FOUND));
+              }
+            });
   }
 
   /**

--- a/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImplTest.java
+++ b/modules/quiz-history/impl/src/test/java/com/icc/qasker/quizhistory/service/QuizHistoryCommandServiceImplTest.java
@@ -2,15 +2,20 @@ package com.icc.qasker.quizhistory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.icc.qasker.global.component.HashUtil;
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.quizhistory.dto.ferequest.SaveHistoryRequest;
 import com.icc.qasker.quizhistory.entity.QuizFolder;
 import com.icc.qasker.quizhistory.entity.QuizHistory;
+import com.icc.qasker.quizhistory.entity.QuizHistory.QuizHistoryStatus;
 import com.icc.qasker.quizhistory.repository.QuizFolderRepository;
 import com.icc.qasker.quizhistory.repository.QuizHistoryRepository;
+import com.icc.qasker.quizset.ProblemSetReadService;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,12 +23,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class QuizHistoryCommandServiceImplTest {
 
   @Mock private QuizHistoryRepository quizHistoryRepository;
   @Mock private QuizFolderRepository quizFolderRepository;
+  @Mock private ProblemSetReadService problemSetReadService;
   @Mock private HashUtil hashUtil;
 
   @InjectMocks private QuizHistoryCommandServiceImpl service;
@@ -82,5 +89,51 @@ class QuizHistoryCommandServiceImplTest {
         .isInstanceOf(CustomException.class)
         .extracting(e -> ((CustomException) e).getMessage())
         .isEqualTo(ExceptionMessage.FOLDER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("saveHistory: 같은 (user,set) 동시 저장 INSERT 충돌을 재조회로 흡수한다 (500 없이 기존 행 완료)")
+  void saveHistory_absorbs_concurrent_insert_race() {
+    QuizHistory existing =
+        QuizHistory.builder().id(7L).userId("u1").problemSetId(10L).title("t").build();
+    when(hashUtil.decode("enc")).thenReturn(10L);
+    when(problemSetReadService.findProblemSetById(10L)).thenReturn(Optional.empty());
+    // 최초 조회는 없음 → save가 유니크 충돌(다른 트랜잭션이 먼저 INSERT) → 재조회는 기존 행 반환
+    when(quizHistoryRepository.findByUserIdAndProblemSetId("u1", 10L))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(existing));
+    when(quizHistoryRepository.save(any()))
+        .thenThrow(new DataIntegrityViolationException("dup (user_id, problem_set_id)"))
+        .thenReturn(existing);
+    when(hashUtil.encode(7L)).thenReturn("encHist");
+
+    SaveHistoryRequest request = new SaveHistoryRequest("enc", "t", List.of(), 3, "00:01:00");
+
+    // 충돌을 던지지 않고(=500 없음) 기존 행으로 흡수해 완료 처리한다.
+    String result = service.saveHistory("u1", request);
+
+    assertThat(result).isEqualTo("encHist");
+    assertThat(existing.getStatus()).isEqualTo(QuizHistoryStatus.COMPLETED);
+    assertThat(existing.getScore()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("saveHistory: 기존 이력이 있으면 새로 만들지 않고 완료 처리한다")
+  void saveHistory_updates_existing() {
+    QuizHistory existing =
+        QuizHistory.builder().id(7L).userId("u1").problemSetId(10L).title("t").build();
+    when(hashUtil.decode("enc")).thenReturn(10L);
+    when(problemSetReadService.findProblemSetById(10L)).thenReturn(Optional.empty());
+    when(quizHistoryRepository.findByUserIdAndProblemSetId("u1", 10L))
+        .thenReturn(Optional.of(existing));
+    when(quizHistoryRepository.save(existing)).thenReturn(existing);
+    when(hashUtil.encode(7L)).thenReturn("encHist");
+
+    String result =
+        service.saveHistory("u1", new SaveHistoryRequest("enc", "t", List.of(), 5, "00:02:00"));
+
+    assertThat(result).isEqualTo("encHist");
+    assertThat(existing.getStatus()).isEqualTo(QuizHistoryStatus.COMPLETED);
+    assertThat(existing.getScore()).isEqualTo(5);
   }
 }


### PR DESCRIPTION
# [fix][BE] quiz_history 저장의 동시성 레이스 흡수 (유니크 충돌 500 제거)

## 요약

같은 (user, problemSet)에 대해 이력 저장이 **동시에** 일어나면 `POST /history`가 간헐적으로 500을 반환하던
사전 존재 결함을 수리한다. 07 사이클에서 이력 mock에 `& !mockai` 가드를 넣어 mockai 기능 E2E가 **실**
`QuizHistoryCommandService`를 타게 되면서 드러난 레이스로, 실 환경(운영, mock 프로파일 없음)에서도 동시
저장 시 발생할 수 있다. 클라이언트 단독 후속(이어풀기 통합)의 기능 확인 중 재관측되어, 사용자 결정으로 이 PR에서 수리한다.

## 증상 · 근본 원인

- **증상**: 결과 화면이 병렬로 열려(예: Playwright `fullyParallel` E2E, 또는 실사용의 빠른 재진입) 같은
  세트의 이력 저장이 동시에 발생하면 일부 요청이 **HTTP 500**. 브라우저 콘솔 `Failed to save quiz history: 500`.
  프론트는 `.catch`로 삼켜 비차단이나, 드물게 이력이 유실될 수 있다.
- **근본 원인**: `saveHistory`의 이력 행 확보가 **비원자적 find-or-create**였다 —
  `findByUserIdAndProblemSetId(...).orElseGet(() -> save(new))`. 두 요청이 모두 "없음"으로 조회한 뒤 둘 다
  `save`(INSERT)를 시도하면 유니크 제약 `uk_quiz_history_user_problem (user_id, problem_set_id)`에 걸려
  `DataIntegrityViolationException` → 500. 메서드가 `@Transactional`이라 충돌이 트랜잭션을 rollback-only로
  오염시켜 같은 트랜잭션 안에서 재조회로 흡수할 수도 없었다.

## 변경

- `saveHistory`의 find-or-create를 `findOrCreateHistory` 헬퍼로 추출하고, **`initHistory`와 동일한
  try-save-catch-refind 패턴**으로 충돌을 흡수한다: `save`가 `DataIntegrityViolationException`을 던지면(=다른
  트랜잭션이 먼저 INSERT함) 재조회로 먼저 만들어진 행을 재사용한다.
- 헬퍼에 **메서드-레벨 `@Transactional`을 두지 않는 것이 핵심** — 각 리포지토리 호출이 독립 트랜잭션이라 한
  요청의 INSERT 충돌이 이 흐름을 오염시키지 않아 이어지는 재조회가 정상 동작한다. `saveHistory`의
  `@Transactional`을 제거하고, `completeQuiz` 변경은 호출부의 명시적 `save`(merge)로 영속한다.
- 채점 재계산(`resolveScore`, REAL_BLANK 서버 채점)·응답 형태는 불변.

## API 실물 예시 (로컬 실측 — 격리 DB, `local,mock,mockai`)

**흐름**: 사용자가 결과 화면에 진입하면 프론트가 응시 답안·점수를 담아 `POST /history`를 호출한다 → 서버가
(user, problemSet) 이력 행을 찾거나(없으면 생성) 완료 상태로 갱신하고, 인코딩된 historyId를 돌려준다. 같은
세트의 동시 호출은 유니크 충돌을 재조회로 흡수해 모두 성공한다.

**① 요청 DTO** (`SaveHistoryRequest`):
```json
{
  "problemSetId": "58Ow4V3x",
  "title": "샘플",
  "userAnswers": [],
  "score": 0,
  "totalTime": "00:01:00"
}
```

**② 저장된 실제 DB ROW** (`quiz_history` 테이블, 실측 — 동시 20요청 후에도 (user,set)당 **1행**):
```
id: 9 | user_id: e2e-realblank | problem_set_id: 1 | status: COMPLETED | score: 0 | total_time: 00:01:00 | answers: []
```

**③ 응답 DTO** (HTTP 201):
```json
{ "historyId": "qZMNgOkr" }
```

## 재발방지 테스트 / 검증

- **단위(`QuizHistoryCommandServiceImplTest`)**:
  - `saveHistory_absorbs_concurrent_insert_race`: 최초 조회 없음 → `save`가 `DataIntegrityViolationException`
    → 재조회로 기존 행 흡수 → 500 없이 완료(COMPLETED)·historyId 반환.
  - `saveHistory_updates_existing`: 기존 행이 있으면 새로 만들지 않고 완료 처리.
- **라이브(격리 DB, `local,mock,mockai`, 실 서비스)**: 같은 세트(`58Ow4V3x`)로 **동시 20 `POST /history`** →
  **전부 201, 500 = 0**, `quiz_history` 행 **1건**(중복 없음). 수정 전에는 동시 저장에서 일부 500.
- `./gradlew build` 전체 그린.

## 작업 브랜치
`fix/history-save-race` (base: `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
